### PR TITLE
removed self-referential dependancy over celluloid gem.

### DIFF
--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -67,18 +67,15 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<celluloid>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 2.3.0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
     else
-      s.add_dependency(%q<celluloid>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 2.3.0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
     end
   else
-    s.add_dependency(%q<celluloid>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 2.3.0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])


### PR DESCRIPTION
Ruby 1.9.2
RubyGems 1.8.1

`gem install celluloid` on a clean system:

"""ERROR:  Error installing celluloid:
    celluloid requires celluloid (>= 0)"""

This commit removes the circular dependency from the gemspec.
