### PR TITLE
ActorProxy#inspect blows up in irb on dead actors

### DIFF
--- a/lib/celluloid/actor_proxy.rb
+++ b/lib/celluloid/actor_proxy.rb
@@ -34,8 +34,11 @@ module Celluloid
     end
 
     def inspect
-      "#<Celluloid::Actor(#{@klass}) dead>" unless alive?
-      Actor.call @mailbox, :inspect
+      if alive?
+        Actor.call @mailbox, :inspect
+      else
+        "#<Celluloid::Actor(#{@klass}) dead>"
+      end
     end
 
     # Create a Celluloid::Future which calls a given method

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -140,6 +140,13 @@ shared_context "a Celluloid Actor" do |included_module|
     actor.inspect.should_not include("@celluloid")
   end
 
+  it "inspects properly when dead" do
+    actor = actor_class.new "Troy McClure"
+    actor.terminate
+    actor.inspect.should match(/Celluloid::Actor\(/)
+    actor.inspect.should include('dead')
+  end
+
   it "allows access to the wrapped object" do
     actor = actor_class.new "Troy McClure"
     actor.wrapped_object.should be_a actor_class


### PR DESCRIPTION
I had some problems following the JamesDean/ElizabethTaylor example in the
README.  Couldn't figure out why the liz actor (actress?) wasn't trapping
the exit exception properly.
