### PR TITLE
Add dependency status via Gemnasium to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Celluloid
 =========
-[![Build Status](http://travis-ci.org/tarcieri/celluloid.png)](http://travis-ci.org/tarcieri/celluloid)
+[![Build Status](http://travis-ci.org/tarcieri/celluloid.png)](http://travis-ci.org/tarcieri/celluloid) [![Dependency Status](https://gemnasium.com/tarcieri/celluloid.png)](https://gemnasium.com/tarcieri/celluloid)
 
 > "I thought of objects being like biological cells and/or individual
 > computers on a network, only able to communicate with messages"


### PR DESCRIPTION
The dependency status is an indicator of how up-to-date the project's gem dependencies are with the latest versions.
