### PR TITLE
Dead actors return proper class name when inspected

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -73,7 +73,7 @@ module Celluloid
       @signals   = Signals.new
       @receivers = Receivers.new
       @timers    = Timers.new
-      @proxy     = ActorProxy.new(@mailbox, self.class.to_s)
+      @proxy     = ActorProxy.new(@mailbox, subject.class.to_s)
       @running   = true
 
       @thread = Pool.get do

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -136,6 +136,7 @@ shared_context "a Celluloid Actor" do |included_module|
   it "inspects properly" do
     actor = actor_class.new "Troy McClure"
     actor.inspect.should match(/Celluloid::Actor\(/)
+    actor.inspect.should match(/#{actor_class}/)
     actor.inspect.should include('@name="Troy McClure"')
     actor.inspect.should_not include("@celluloid")
   end
@@ -144,6 +145,7 @@ shared_context "a Celluloid Actor" do |included_module|
     actor = actor_class.new "Troy McClure"
     actor.terminate
     actor.inspect.should match(/Celluloid::Actor\(/)
+    actor.inspect.should match(/#{actor_class}/)
     actor.inspect.should include('dead')
   end
 


### PR DESCRIPTION
Inspecting a dead actor used to produce an uninformative
"Celluloid::Actor(Celluloid::Actor) dead" message.
