### PR TITLE
Added Celluloid::Actor#exclusive

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -16,6 +16,11 @@ module Celluloid
       !!Thread.current[:actor]
     end
 
+    # Is current actor running in exclusive mode?
+    def exclusive?
+      actor? and Thread.current[:actor].exclusive?
+    end
+
     # Obtain the currently running actor (if one exists)
     def current_actor
       actor = Thread.current[:actor]
@@ -191,6 +196,12 @@ module Celluloid
   # Sleep while letting the actor continue to receive messages
   def sleep(interval)
     Celluloid.sleep(interval)
+  end
+
+  # Run given block in an exclusive mode: all synchronous calls block the whole
+  # actor, not only current message processing.
+  def exclusive(&block)
+    Thread.current[:actor].exclusive(&block)
   end
 
   # Call a block after a given interval

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -32,7 +32,7 @@ module Celluloid
         raise DeadActorError, "attempted to call a dead actor"
       end
 
-      if Celluloid.actor?
+      if Celluloid.actor? and not Celluloid.exclusive?
         # The current task will be automatically resumed when we get a response
         Task.suspend :callwait
       else
@@ -85,6 +85,7 @@ module Celluloid
       @receivers = Receivers.new
       @timers    = Timers.new
       @running   = true
+      @exclusive = false
 
       @thread = ThreadPool.get do
         Thread.current[:actor]   = self
@@ -97,6 +98,19 @@ module Celluloid
     # Is this actor alive?
     def alive?
       @running
+    end
+
+    # Is this actor running in exclusive mode?
+    def exclusive?
+      @exclusive
+    end
+
+    # Execute a code block in exclusive mode.
+    def exclusive
+      @exclusive = true
+      yield
+    ensure
+      @exclusive = false
     end
 
     # Terminate this actor
@@ -175,7 +189,7 @@ module Celluloid
     def sleep(interval)
       task = Task.current
       @timers.add(interval) { task.resume }
-      Task.suspend :sleeping
+      Task.suspend :sleeping unless Celluloid.exclusive?
     end
 
     # Handle an incoming message

--- a/lib/celluloid/receivers.rb
+++ b/lib/celluloid/receivers.rb
@@ -20,7 +20,7 @@ module Celluloid
       end
 
       @receivers << receiver
-      Task.suspend :receiving
+      Task.suspend :receiving unless Celluloid.exclusive?
     end
 
     # How long to wait until the next timer fires

--- a/lib/celluloid/signals.rb
+++ b/lib/celluloid/signals.rb
@@ -20,7 +20,7 @@ module Celluloid
         @waiting[signal] = [tasks, Task.current]
       end
 
-      Task.suspend :sigwait
+      Task.suspend :sigwait unless Celluloid.exclusive?
     end
 
     # Send a signal to all method calls waiting for the given name


### PR DESCRIPTION
It runs given block in an exclusive mode: all synchronous
calls block the whole actor, not only current message processing.
