### PR TITLE
raise an exception if :args is not an Array on Celluloid::Group.supervise

### DIFF
--- a/lib/celluloid/group.rb
+++ b/lib/celluloid/group.rb
@@ -71,6 +71,7 @@ module Celluloid
 
         @as = options['as']
         @args = options['args'] || []
+        raise ":args should be an Array" unless @args.kind_of? Array
       end
 
       def supervise


### PR DESCRIPTION
Making the supervise method in Celluloid::Group raise an exception if :args is not an Array.
This corresponds to the tweak to the wiki page https://github.com/celluloid/celluloid/wiki/Groups
that shows how to correctly use the :args param with the supervise method.

This informs the programmer they screwed up (via exception) when they do things like: (WRONG)
  supervise TheActor, :as => :the_actor, :args => {:start_working => true}
instead of: (CORRECT)
  supervise TheActor, :as => :the_actor, :args => [{:start_working => true}]

When you do this the incorrect way, like shown, it ends up sending args to constructor like:
TheActor.new([[:start_working,true]], which is quite confusing (I suppose Ruby must type cast args to an array when called like *@args)...
