### PR TITLE
[BUGFIX] Ensure a Pool has a minimum size of 2

### DIFF
--- a/lib/celluloid/pool.rb
+++ b/lib/celluloid/pool.rb
@@ -3,6 +3,7 @@ module Celluloid
   class Pool
     include Celluloid
     trap_exit :crash_handler
+    attr_reader :max_actors
 
     # Takes a class of actor to pool and a hash of options:
     #
@@ -10,9 +11,10 @@ module Celluloid
     # * max_size: maximum number of actors (default one actor per CPU core)
     # * args: an array of arguments to pass to the actor's initialize
     def initialize(klass, options = {})
+      raise ArgumentError, "A Pool has a minimum size of 2" if options[:max_size] && options[:max_size] < 2
       opts = {
         :initial_size => 1,
-        :max_size     => Celluloid.cores,
+        :max_size     => [Celluloid.cores, 2].max,
         :args         => []
       }.merge(options)
 

--- a/spec/celluloid/pool_spec.rb
+++ b/spec/celluloid/pool_spec.rb
@@ -53,4 +53,44 @@ describe Celluloid::Pool do
     expect { subject.get { |actor| actor.crash } }.to raise_exception(ExampleError)
     subject.idle_count.should == 0
   end
+
+  context "when not specifying a size limit" do
+    before { Celluloid.should_receive(:cores).and_return num_cores }
+
+    context "with a number of cores > 1" do
+      let(:num_cores) { 4 }
+
+      it "should create a pool of size Celluloid.cores" do
+        subject.max_actors.should be == 4
+      end
+    end
+
+    context "with a number of cores < 2" do
+      let(:num_cores) { 1 }
+
+      it "should create a pool of size 2" do
+        subject.max_actors.should be == 2
+      end
+    end
+  end
+
+  context "when specifying a size limit" do
+    subject { Celluloid::Pool.new ExampleActor, :max_size => size }
+
+    context "> 1" do
+      let(:size) { 3 }
+
+      it "should create a pool of the size specified" do
+        subject.max_actors.should be == 3
+      end
+    end
+
+    context "< 2" do
+      let(:size) { 1 }
+
+      it "should raise ArgumentError" do
+        lambda { subject }.should raise_error(ArgumentError, /minimum size of 2/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Default value is the number of cores, but not less than 2
- If a size of less than 2 is specified, raise ArgumentError

Fixes #39
