### PR TITLE
Clearer error messages when method call has bad argument count.

### DIFF
--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -24,12 +24,16 @@ module Celluloid
 
       if arity >= 0
         if arguments.size != arity
-          raise ArgumentError, "wrong number of arguments (#{arguments.size} for #{arity})"
+          raise ArgumentError, 
+            "wrong number of arguments (#{arguments.size} for #{arity}) " +
+            "for `#{@method}` on #{obj.inspect}"
         end
       elsif arity < -1
         mandatory_args = -arity - 1
         if arguments.size < mandatory_args
-          raise ArgumentError, "wrong number of arguments (#{arguments.size} for #{mandatory_args})"
+          raise ArgumentError, 
+            "wrong number of arguments (#{arguments.size} for " +
+            "#{mandatory_args}) for `#{@method}` on #{obj.inspect}"
         end
       end
     end


### PR DESCRIPTION
'cause its impossible to say what went wrong from this:

```
Server has encountered an error!

[2012-04-02 19:39:55.140|Ax10ac|main|error] Dispatcher: async call failed!
ArgumentError: wrong number of arguments (1 for 2)
/home/spacegame/nebula-server/20120402193026/vendor/bundle/jruby/1.9/gems/celluloid-0.10.0/lib/celluloid/calls.rb:32:in `check_signature'
/home/spacegame/nebula-server/20120402193026/vendor/bundle/jruby/1.9/gems/celluloid-0.10.0/lib/celluloid/calls.rb:92:in `dispatch'
/home/spacegame/nebula-server/20120402193026/vendor/bundle/jruby/1.9/gems/celluloid-0.10.0/lib/celluloid/actor.rb:212:in `handle_message'
/home/spacegame/nebula-server/20120402193026/vendor/bundle/jruby/1.9/gems/celluloid-0.10.0/lib/celluloid/task.rb:45:in `initialize'
/home/spacegame/nebula-server/20120402193026/vendor/bundle/jruby/1.9/gems/celluloid-0.10.0/lib/celluloid/task.rb:44:in `initialize'
```
