### PR TITLE
Unify the Supervisor and SupervisionGroup classes

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -19,10 +19,21 @@ module Celluloid
   # normal Ruby objects wrapped in threads which communicate with asynchronous
   # messages.
   class Actor
-    extend Registry
     attr_reader :subject, :proxy, :tasks, :links, :mailbox, :thread, :name
 
     class << self
+      extend Forwardable
+
+      def_delegators "Celluloid::Registry.root", :[], :[]=
+
+      def registered
+        Registry.root.names
+      end
+
+      def clear_registry
+        Registry.root.clear
+      end
+
       # Obtain the current actor
       def current
         actor = Thread.current[:actor]

--- a/lib/celluloid/supervisor.rb
+++ b/lib/celluloid/supervisor.rb
@@ -2,68 +2,21 @@ module Celluloid
   # Supervisors are actors that watch over other actors and restart them if
   # they crash
   class Supervisor
-    include Celluloid
-    trap_exit :restart_actor
-
-    # Retrieve the actor this supervisor is supervising
-    attr_reader :actor
-
     class << self
       # Define the root of the supervision tree
       attr_accessor :root
 
       def supervise(klass, *args, &block)
-        new(nil, klass, *args, &block)
+        SupervisionGroup.new do |group|
+          group.supervise klass, *args, &block
+        end
       end
 
       def supervise_as(name, klass, *args, &block)
-        new(name, klass, *args, &block)
-      end
-    end
-
-    def initialize(name, klass, *args, &block)
-      @name, @klass, @args, @block = name, klass, args, block
-      @started = false
-
-      start_actor
-    end
-
-    def finalize
-      @actor.terminate if @actor and @actor.alive?
-    end
-
-    def start_actor(start_attempts = 3, sleep_interval = 30)
-      failures = 0
-
-      begin
-        @actor = @klass.new_link(*@args, &@block)
-      rescue
-        failures += 1
-        if failures >= start_attempts
-          failures = 0
-
-          Logger.warn("#{@klass} is crashing on initialize too quickly, sleeping for #{sleep_interval} seconds")
-          sleep sleep_interval
+        SupervisionGroup.new do |group|
+          group.supervise_as name, klass, *args, &block
         end
-        retry
       end
-
-      @started = true
-      Actor[@name] = @actor if @name
-    end
-
-    # When actors die, regardless of the reason, restart them
-    def restart_actor(actor, reason)
-      # If the actor we're supervising exited cleanly, exit the supervisor cleanly too
-      terminate unless reason
-
-      start_actor if @started
-    end
-
-    def inspect
-      str = "#<#{self.class}(#{@klass}):0x#{object_id.to_s(16)}"
-      str << " " << @args.map { |arg| arg.inspect }.join(' ') unless @args.empty?
-      str << ">"
     end
   end
 end

--- a/spec/celluloid/supervisor_spec.rb
+++ b/spec/celluloid/supervisor_spec.rb
@@ -24,7 +24,7 @@ describe Celluloid::Supervisor do
 
   it "restarts actors when they die" do
     supervisor = Celluloid::Supervisor.supervise(Subordinate, :idle)
-    subordinate = supervisor.actor
+    subordinate = supervisor.actors.first
     subordinate.state.should == :idle
 
     subordinate.crack_the_whip
@@ -36,7 +36,7 @@ describe Celluloid::Supervisor do
     sleep 0.1 # hax to prevent race :(
     subordinate.should_not be_alive
 
-    new_subordinate = supervisor.actor
+    new_subordinate = supervisor.actors.first
     new_subordinate.should_not == subordinate
     new_subordinate.state.should == :idle
   end
@@ -62,7 +62,7 @@ describe Celluloid::Supervisor do
 
   it "creates supervisors via Actor.supervise" do
     supervisor = Subordinate.supervise(:working)
-    subordinate = supervisor.actor
+    subordinate = supervisor.actors.first
     subordinate.state.should == :working
 
     expect do
@@ -71,7 +71,7 @@ describe Celluloid::Supervisor do
     sleep 0.1 # hax to prevent race :(
     subordinate.should_not be_alive
 
-    new_subordinate = supervisor.actor
+    new_subordinate = supervisor.actors.first
     new_subordinate.should_not == subordinate
     new_subordinate.state.should == :working
   end
@@ -87,7 +87,7 @@ describe Celluloid::Supervisor do
     sleep 0.1 # hax to prevent race :(
     subordinate.should_not be_alive
 
-    new_subordinate = supervisor.actor
+    new_subordinate = supervisor.actors.first
     new_subordinate.should_not == subordinate
     new_subordinate.state.should == :working
   end


### PR DESCRIPTION
- Allow SupervisionGroup to be used without subclassing
- Separate the Registry from Actor
