### PR TITLE
Missing parameter “include_private” to respond_to? for ActorProxy

### DIFF
--- a/lib/celluloid/actor_proxy.rb
+++ b/lib/celluloid/actor_proxy.rb
@@ -29,8 +29,8 @@ module Celluloid
       Actor.call @mailbox, :kind_of?, klass
     end
 
-    def respond_to?(meth)
-      Actor.call @mailbox, :respond_to?, meth
+    def respond_to?(meth, include_private = false)
+      Actor.call @mailbox, :respond_to?, meth, include_private
     end
 
     def methods(include_ancestors = true)

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -54,6 +54,12 @@ shared_context "a Celluloid Actor" do |included_module|
     actor.first.should be == :bar
   end
 
+  it "properly handles respond_to with include_private" do
+    actor = actor_class.new "Method missing privates"
+    actor.respond_to?(:zomg_private).should be_false
+    actor.respond_to?(:zomg_private, true).should be_true
+  end
+
   it "raises NoMethodError when a nonexistent method is called" do
     actor = actor_class.new "Billy Bob Thornton"
 

--- a/spec/support/example_actor_class.rb
+++ b/spec/support/example_actor_class.rb
@@ -55,7 +55,7 @@ module ExampleActorClass
         end
       end
 
-      def respond_to?(method_name)
+      def respond_to?(method_name, include_private = false)
         super || delegates?(method_name)
       end
 


### PR DESCRIPTION
Please excuse my boldness opening an issue without a proper discussion
beforehand. Aaanyway…

Ruby’s own objects include this parameter (1), which when set to true also
takes into account private methods when looking up if the object responds
to the given method or not.

(1): http://ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F
