### PR TITLE
make it possible to wrap an actor around a non-celluloid object

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -162,12 +162,12 @@ module Celluloid
     end
 
     # Wrap the given subject with an Actor
-    def initialize(subject)
+    def initialize(subject, meta = subject.class)
       @subject      = subject
-      @mailbox      = subject.class.mailbox_factory
-      @exit_handler = subject.class.exit_handler
-      @exclusives   = subject.class.exclusive_methods
-      @task_class   = subject.class.task_class || Celluloid.task_class
+      @mailbox      = meta.mailbox_factory
+      @exit_handler = meta.exit_handler
+      @exclusives   = meta.exclusive_methods
+      @task_class   = meta.task_class || Celluloid.task_class
 
       @tasks     = Set.new
       @links     = Links.new


### PR DESCRIPTION
I'm looking at adding some light concurrency to a series of existing objects with the same interface, and I'd rather not modify all of them to included celluloid.  I could create a light wrapper, but celluloid is already providing one layer of proxy.  After a little poking, I found that it was really quite close to being able to wrap an actor around any object, albeit with restricted abilities.

I'd appreciated your thoughts on how to test the new constructor form.  Main options would be
1. Instantiate an object with the two-argument form and run a few smoke-tests
2. Split the actor tests into 'extras' and 'speaking roles', so to speak, which might impact other clients of the shared specs.
