### PR TITLE
Added second parameter to SupervisionGroup.pool method to pass options hash

### DIFF
--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -44,9 +44,13 @@ module Celluloid
       end
 
       # Register a pool of actors to be launched on group startup
-      def pool(klass)
+      # Available options are:
+      #
+      # * as: register this application in the Celluloid::Actor[] directory
+      # * args: start the actor pool with the given arguments
+      def pool(klass, options = {})
         blocks << lambda do |group|
-          group.pool klass
+          group.pool klass, options
         end
       end
     end
@@ -67,8 +71,11 @@ module Celluloid
       add(klass, :args => args, :block => block, :as => name)
     end
 
-    def pool(klass)
-      add(klass, :method => 'pool_link')
+    def pool(klass, options = {})
+      # stringify keys :/
+      options = options.inject({}) { |h,k,v| h[k.to_s] = v; h }
+      options['method'] = 'pool_link'
+      add(klass, options)
     end
 
     def add(klass, options)


### PR DESCRIPTION
Now you can do something like the following:

```
class MyGroup < Celluloid::SupervisionGroup
  pool Worker, as: :worker_pool
end
```

Without this patch the same can be done using the following:

```
class MyGroup < Celluloid::SupervisionGroup
  supervise Worker, as: :worker_pool, method: 'pool_link'
end
```
