### PR TITLE
make the actor configuration an explicit options argument

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -162,12 +162,12 @@ module Celluloid
     end
 
     # Wrap the given subject with an Actor
-    def initialize(subject)
+    def initialize(subject, options = {})
       @subject      = subject
-      @mailbox      = subject.class.mailbox_factory
-      @exit_handler = subject.class.exit_handler
-      @exclusives   = subject.class.exclusive_methods
-      @task_class   = subject.class.task_class || Celluloid.task_class
+      @mailbox      = options[:mailbox] || Mailbox.new
+      @exit_handler = options[:exit_handler]
+      @exclusives   = options[:exclusive_methods]
+      @task_class   = options[:task_class] || Celluloid.task_class
 
       @tasks     = Set.new
       @links     = Links.new


### PR DESCRIPTION
Here is the easy part.

The option defaults aren't fully tested yet.  The easy way out would be to add a short smoke test - create an actor and send an async message to make sure nothing blows up.

Doing it properly would be a bit more traumatic - I'd want to disentangle the Actor tests from the ClassMethod tests, and possibly lift the Celluloid methods into a submodule that could be included without triggering the included hook in order to make that work.
