### PR TITLE
1.9.2 BasicObject does not include object_id, also hash was not returning varying values

### DIFF
--- a/lib/celluloid/actor_proxy.rb
+++ b/lib/celluloid/actor_proxy.rb
@@ -14,8 +14,16 @@ module Celluloid
     end
 
     # Needed for storing proxies in data structures
-    def hash
-      ::Kernel.hash
+    needed = [:object_id, :__id__, :hash] - instance_methods
+    if needed.any?
+      include ::Kernel.dup.module_eval {
+        undef_method *(instance_methods - needed)
+        self
+      }
+
+      # rubinius bug?  These methods disappear when we include hacked kernel
+      define_method :==, ::BasicObject.instance_method(:==) unless instance_methods.include?(:==)
+      alias_method(:equal?, :==) unless instance_methods.include?(:equal?)
     end
 
     def class

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -19,6 +19,12 @@ shared_context "a Celluloid Actor" do |included_module|
     end.should be_true
   end
 
+  it "can be stored in hashes" do
+    actor = actor_class.new "Troy McClure"
+    actor.hash.should_not == Kernel.hash
+    actor.object_id.should_not == Kernel.object_id
+  end
+
   it "handles synchronous calls" do
     actor = actor_class.new "Troy McClure"
     actor.greet.should == "Hi, I'm Troy McClure"


### PR DESCRIPTION
Sidekiq is using object_id to store actor_proxies; this breaks for dead actors with the BasicObject proxy, because 1.9.2 doesn't include object_id.

I'm not thrilled with the solution, see [discussion on ruby-trunk](http://www.ruby-forum.com/topic/4333153) for origin.  Alternate implementations welcome.

Also, I noticed that ActorProxy#hash was returning an effective constant.
