### PR TITLE
workaround MRI bug in preserving exit status in at_exit

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -73,7 +73,17 @@ module Celluloid
   end
 
   # Terminate all actors at exit
-  at_exit { shutdown }
+  at_exit do
+    if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
+      # workaround for MRI bug losing exit status in at_exit block
+      # http://bugs.ruby-lang.org/issues/5218
+      exit_status = $!.status if $!.is_a?(SystemExit)
+      shutdown
+      exit exit_status if exit_status
+    else
+      shutdown
+    end
+  end
 
   # Class methods added to classes which include Celluloid
   module ClassMethods


### PR DESCRIPTION
http://bugs.ruby-lang.org/issues/5218

Sorry, no tests included in this commit. I'm not sure what the reasonable way to add a test for this is, if you have an idea let me know. 

I did confirm that this fixes the problem where celluloid caused my CI process to always exit 0 even with failures, in MRI. And that existing celluloid tests still pass. 
