### PR TITLE
Make CPU counter try a little harder for linux OS

### DIFF
--- a/lib/celluloid/cpu_counter.rb
+++ b/lib/celluloid/cpu_counter.rb
@@ -6,7 +6,7 @@ module Celluloid
     when 'darwin'
       @cores = Integer(`sysctl hw.ncpu`[/\d+/])
     when 'linux'
-      @cores = File.read("/proc/cpuinfo").scan(/core id\s+: \d+/).uniq.size
+      @cores = File.read("/proc/cpuinfo").scan(/(?:core id|processor)\s+: \d+/).uniq.size
     when 'mingw', 'mswin'
       @cores = Integer(`SET NUMBER_OF_PROCESSORS`[/\d+/])
     else


### PR DESCRIPTION
Since the /proc/cpuinfo file format has no standard, and ubuntu (or the version we use)
says 'processor' not 'core id'.
