### PR TITLE
added use_proxy to switch actor proxy class

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -170,6 +170,10 @@ module Celluloid
     def mailbox_class(klass)
       @mailbox_factory = proc { klass.new }
     end
+    
+    def proxy_class(klass)
+      @proxy_factory = proc { klass }
+    end
 
     # Define the default task type for this class
     def task_class(klass = nil)
@@ -204,11 +208,22 @@ module Celluloid
         Mailbox.new
       end
     end
+    
+    def proxy_factory
+      if defined?(@proxy_factory)
+        @proxy_factory.call
+      elsif superclass.respond_to?(:proxy_factory)
+        superclass.proxy_factory
+      else
+        nil
+      end
+    end
 
     # Configuration options for Actor#new
     def actor_options
       {
         :mailbox           => mailbox_factory,
+        :proxy_class       => proxy_factory,
         :exit_handler      => exit_handler,
         :exclusive_methods => @exclusive_methods,
         :task_class        => task_class

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -163,6 +163,7 @@ module Celluloid
     def initialize(subject, options = {})
       @subject      = subject
       @mailbox      = options[:mailbox] || Mailbox.new
+      @proxy_class  = options[:proxy_class] || ActorProxy
       @exit_handler = options[:exit_handler]
       @exclusives   = options[:exclusive_methods]
       @task_class   = options[:task_class] || Celluloid.task_class
@@ -181,8 +182,8 @@ module Celluloid
         Thread.current[:mailbox] = @mailbox
         run
       end
-
-      @proxy = ActorProxy.new(self)
+      
+      @proxy = @proxy_class.new(self)
     end
 
     # Run the actor loop

--- a/lib/celluloid/proxies/actor_proxy.rb
+++ b/lib/celluloid/proxies/actor_proxy.rb
@@ -10,7 +10,10 @@ module Celluloid
       @async_proxy  = AsyncProxy.new(actor)
       @future_proxy = FutureProxy.new(actor)
     end
-
+    
+    # allow querying the real class
+    alias :__class__ :class
+    
     def class
       Actor.call @mailbox, :__send__, :class
     end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -676,6 +676,26 @@ shared_context "a Celluloid Actor" do |included_module|
       actor.tasks.size.should == 1
     end
   end
+  
+  context :proxy_class do
+    class ExampleProxy < Celluloid::ActorProxy; end
+
+    subject do
+      Class.new do
+        include included_module
+        proxy_class ExampleProxy
+      end
+    end
+
+    it "uses user-specified proxy" do
+      subject.new.__class__.should == ExampleProxy
+    end
+
+    it "retains custom proxy when subclassed" do
+      subclass = Class.new(subject)
+      subclass.new.__class__.should == ExampleProxy
+    end
+  end
 
   context :use_mailbox do
     class ExampleMailbox < Celluloid::Mailbox; end


### PR DESCRIPTION
For a specific use case I needed to subclass the ActorProxy, here is my patch to allow switching the implementation.
I tried to match the implementation of use_mailbox and added a use_proxy class method.

I had to add a way to query the proxy class since it does a really good job at hiding itself (a little too much in my opinion).
