### PR TITLE
Run blocks on caller by default

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -98,7 +98,7 @@ module Celluloid
     # Create a new actor
     def new(*args, &block)
       proxy = Actor.new(allocate, actor_options).proxy
-      proxy._send_(:initialize, *args, &block)
+      Actor.raw_call(proxy.mailbox, true, :__send__, :initialize, *args, &block)
       proxy
     end
     alias_method :spawn, :new

--- a/lib/celluloid/future.rb
+++ b/lib/celluloid/future.rb
@@ -12,7 +12,7 @@ module Celluloid
       @forwards = nil
 
       if block
-        @call = SyncCall.new(self, :call, args)
+        @call = SyncCall.new(self, false, :call, args)
         InternalPool.get do
           begin
             @call.dispatch(block)
@@ -29,7 +29,7 @@ module Celluloid
     def execute(receiver, method, args, block)
       @mutex.synchronize do
         raise "already calling" if @call
-        @call = SyncCall.new(self, method, args, block)
+        @call = SyncCall.new(self, false, method, args, block)
       end
 
       receiver << @call

--- a/lib/celluloid/proxies/actor_proxy.rb
+++ b/lib/celluloid/proxies/actor_proxy.rb
@@ -19,6 +19,14 @@ module Celluloid
       Actor.call @mailbox, :__send__, meth, *args, &block
     end
 
+    def after(interval, &block)
+      Actor.raw_call @mailbox, true, :after, interval, &block
+    end
+
+    def every(interval, &block)
+      Actor.raw_call @mailbox, true, :every, interval, &block
+    end
+
     def inspect
       Actor.call(@mailbox, :inspect).sub(::Celluloid::BARE_OBJECT_WARNING_MESSAGE, "Celluloid::Actor")
     rescue DeadActorError

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -183,7 +183,11 @@ shared_context "a Celluloid Actor" do |included_module|
     actor = actor_class.new "Troy McClure"
     actor.run do
       Celluloid.actor?
+    end.should be_false
+    Celluloid::Actor.raw_call(actor.mailbox, true, :run) do
+      Celluloid.actor?
     end.should be_true
+    actor.should be_actor
   end
 
   it "inspects properly" do
@@ -608,6 +612,22 @@ shared_context "a Celluloid Actor" do |included_module|
 
       sleep(interval + Celluloid::TIMER_QUANTUM) # wonky! #/
       actor.should_not be_fired
+    end
+
+    it "allows delays from outside the actor" do
+      actor = @klass.new
+
+      interval = Celluloid::TIMER_QUANTUM * 10
+      started_at = Time.now
+      fired = false
+
+      timer = actor.after(interval) do
+        fired = true
+      end
+      fired.should be_false
+
+      sleep(interval + Celluloid::TIMER_QUANTUM) # wonky! #/
+      fired.should be_true
     end
   end
 

--- a/spec/support/example_actor_class.rb
+++ b/spec/support/example_actor_class.rb
@@ -25,6 +25,10 @@ module ExampleActorClass
         "Hi, I'm #{@name}"
       end
 
+      def actor?
+        Celluloid.actor?
+      end
+
       def run(*args)
         yield(*args)
       end


### PR DESCRIPTION
I finally got around to getting this working. 

See #55 and [the wiki page](https://github.com/celluloid/celluloid/wiki/Blocks)

There is currently no simple way to call a method and have the blocks be executed in the destination `Actor`'s `Thread`. 

I could do this, but here is a first pass. 
