### PR TITLE
Without autostart

### DIFF
--- a/lib/celluloid/boot.rb
+++ b/lib/celluloid/boot.rb
@@ -1,10 +1,23 @@
 # Things to run after Celluloid is fully loaded
+module Celluloid
+  module_function
+  
+  def start
+    unless @started
+      # Configure default systemwide settings
+      Celluloid.task_class = Celluloid::TaskFiber
+      Celluloid.logger     = ::Logger.new(STDERR)
+      
+      # Launch default services
+      # FIXME: We should set up the supervision hierarchy here
+      Celluloid::Notifications::Fanout.supervise_as :notifications_fanout
+      Celluloid::IncidentReporter.supervise_as :default_incident_reporter, STDERR
+      @started = true
+    end
+  end
+end
 
-# Configure default systemwide settings
-Celluloid.task_class = Celluloid::TaskFiber
-Celluloid.logger     = Logger.new(STDERR)
 
-# Launch default services
-# FIXME: We should set up the supervision hierarchy here
-Celluloid::Notifications::Fanout.supervise_as :notifications_fanout
-Celluloid::IncidentReporter.supervise_as :default_incident_reporter, STDERR
+unless defined?(CELLULOID_DISABLE_AUTOSTART)
+  Celluloid.start()
+end


### PR DESCRIPTION
Here is something concrete to add to the discution :)
I was sure it would be easy but did not expect it to be that easy, this patch allows to do this:

``` ruby
require 'celluloid'
# use celluloid as before, nothing changed
```

or this:

``` ruby
require 'celluloid/without_autostart'

# do what you want WITHOUT celluloid

Celluloid.start()

# use celluloid as before
```

And as a bonus you can even call "Celluloid.start()" as many times as you want, the system will only be started once.

So what do you think of this ?

As for the documentation the more I think of it the more I think it should not be documented, if you need this for a good reason you will know where to look.

PS: Github do not shows correctly the file rename, the real diff is really small.
