### PR TITLE
Add finalizer :callback API.

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -157,6 +157,17 @@ module Celluloid
     end
     alias_method :trap_exit, :exit_handler
 
+    # Define a callback to run when the actor is finalized.
+    def finalizer(callback = nil)
+      if callback
+        @finalizer = callback.to_sym
+      elsif defined?(@finalizer)
+        @finalizer
+      elsif superclass.respond_to? :finalizer
+        superclass.finalizer
+      end
+    end
+
     # Configure a custom mailbox factory
     def use_mailbox(klass = nil, &block)
       if block

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -93,6 +93,13 @@ shared_context "a Celluloid Actor" do |included_module|
     end.to raise_exception(ExampleCrash)
   end
 
+  it "calls the user defined finalizer" do
+    actor = actor_class.new "Mr. Bean"
+    actor.wrapped_object.should_receive(:my_finalizer)
+    actor.terminate
+    Celluloid::Actor.join(actor)
+  end
+
   describe "when #abort is called" do
     it "raises exceptions in the caller but keeps running" do
       actor = actor_class.new "Al Pacino"

--- a/spec/support/example_actor_class.rb
+++ b/spec/support/example_actor_class.rb
@@ -3,6 +3,7 @@ module ExampleActorClass
     Class.new do
       include included_module
       attr_reader :name
+      finalizer :my_finalizer
 
       def initialize(name)
         @name = name
@@ -72,6 +73,9 @@ module ExampleActorClass
       end
       private :zomg_private
       attr_reader :private_called
+
+      def my_finalizer
+      end
 
       private
 


### PR DESCRIPTION
Given a class that traps exits and implements a finalizer, the mix of API styles looks a little odd.

This PR adds a finalizer class method:

``` ruby
class Foo
  include Celluloid
  finalizer :my_finalizer

  def my_finalizer
  end
end
```

This also deprecates the old `finalize` method style.
