### PR TITLE
Grow, shrink a pool

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -313,6 +313,11 @@ module Celluloid
     Actor.name
   end
 
+  # Obtain the current actor's mailbox
+  def mailbox
+    current_actor.mailbox
+  end
+
   # Obtain the running tasks for this actor
   def tasks
     Thread.current[:actor].tasks.to_a

--- a/lib/celluloid/mailbox.rb
+++ b/lib/celluloid/mailbox.rb
@@ -105,6 +105,11 @@ module Celluloid
       true
     end
 
+    # Number of queued messages
+    def size
+      @messages.size
+    end
+
     # Is the mailbox alive?
     def alive?
       !@dead

--- a/lib/celluloid/proxies/actor_proxy.rb
+++ b/lib/celluloid/proxies/actor_proxy.rb
@@ -53,6 +53,10 @@ module Celluloid
       @mailbox.alive?
     end
 
+    def mailbox_size
+      @mailbox.size
+    end
+
     def to_s
       Actor.call @mailbox, :to_s
     end

--- a/spec/celluloid/pool_spec.rb
+++ b/spec/celluloid/pool_spec.rb
@@ -21,7 +21,7 @@ describe "Celluloid.pool" do
     end
   end
 
-  subject { MyWorker.pool }
+  subject { MyWorker.pool(size: 2) }
 
   it "processes work units synchronously" do
     subject.process.should == :done
@@ -50,5 +50,21 @@ describe "Celluloid.pool" do
 
   it "terminates" do
     expect { subject.terminate }.to_not raise_exception
+  end
+
+  it "grows the number of workers" do
+    expect { subject.grow(1) }.to change(subject, :size).by(1)
+  end
+
+  it "shrinks the number of workers" do
+    expect { subject.shrink(1) }.to change(subject, :size).by(-1)
+  end
+
+  it "does not shrink the pool below zero" do
+    expect { subject.shrink(100) }.to change(subject, :size).to(0)
+  end
+
+  it "requires at least one worker" do
+    expect { MyWorker.pool(size: 0) }.to raise_error(ArgumentError, 'minimum pool size is 1')
   end
 end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -214,6 +214,12 @@ shared_context "a Celluloid Actor" do |included_module|
     actor.wrapped_object.inspect.should include Celluloid::BARE_OBJECT_WARNING_MESSAGE
   end
 
+  it "returns the mailbox size" do
+    actor = actor_class.new "Mr. Bean"
+    actor.async.block(0.1)
+    actor.mailbox_size.should eq 1
+  end
+
   describe 'mocking methods' do
     let(:actor) { actor_class.new "Troy McClure" }
 

--- a/spec/support/example_actor_class.rb
+++ b/spec/support/example_actor_class.rb
@@ -25,6 +25,10 @@ module ExampleActorClass
         "Hi, I'm #{@name}"
       end
 
+      def block(time)
+        sleep time
+      end
+
       def run(*args)
         yield(*args)
       end


### PR DESCRIPTION
This adds the ability to grow, shrink a pool and inspect its mailbox message queue size.
- The minimum pool size is now 1. I have a use case where a pool can be grown, shrunk dynamically via HUP signals. Users may choose to shrink to 1, or even 0 during low traffic periods.
- `mailbox_size` is defined on the ActorProxy, which of course exposes this to all actors. Perhaps this method is also useful for single actors.
