### PR TITLE
Add Cellulate, a late init Celluloid mixin

### DIFF
--- a/examples/cellulate.rb
+++ b/examples/cellulate.rb
@@ -27,8 +27,9 @@ rescue => e
   puts "We failed because we dont know the future: #{e}"
 end
 puts "#{base_fibber.class} methods count before conversion: #{base_fibber.methods.count}"
-base_fibber.extend(Cellulate)
-base_fibber = base_fibber.cellulate
+base_fibber.extend(Celluloid::Cellulate)
+# call protected method
+base_fibber = base_fibber.send(:cellulate)
 puts "#{base_fibber.class} methods count after conversion: #{base_fibber.methods.count}"
 
 base_future = base_fibber.future(:fib,11)

--- a/lib/celluloid/cellulate.rb
+++ b/lib/celluloid/cellulate.rb
@@ -1,13 +1,42 @@
 require 'celluloid'
 
-module Cellulate
+module Celluloid::Cellulate
+
+  ##
+  # WARNING, DANGER, ATTENTION, ETC:
+  # USING THIS MODULE CAN LEAD TO AWFUL THINGS HAPPNING.
+  #
+  # This module is designed to perform late init for celluloid
+  # objects. It is intended for instantiated objects which are
+  # conditionally extended during construction, and not as a late
+  # backgrounding method for existing objects which exist elsewhere.
+  #
+  # Ruby 1.9 does not allow reassignment of self, or rather the
+  # value at the address of the object contextually defined as self.
+  # This means that if an object is instantiated, and is referenced
+  # by some other context, then the using this method will not replace
+  # the object in that context with the proxy created here.
+  # The result can lead to calls on the raw object...
+  #
+  # Example of how things go wrong:
+  # obj = Object.new; ar = []; ar << obj; obj.extend(Celluloid::Cellulate)
+  # obj = obj.send(:cellulate)
+  # ar[0] != obj
+  #
+  # YOU HAVE BEEN WARNED...
+  ##
 
   # Required when building an Actor
   def superclass
     self.class
   end
 
-  # Use this mixin for late conversion to a cell
+  # Force the developer to try harder in hopes they read the warning.
+  private
+
+  # Use this method for converting to a celluloid object
+  # Ex: obj = obj.send(:cellulate)
+  # TODO: log this terrible event, log rescues
   def cellulate
     # Ensure there is no current actor
     curr_act = nil
@@ -23,8 +52,11 @@ module Cellulate
     self.extend(Celluloid::ClassMethods)
     self.class.send(:include, Celluloid::InstanceMethods)
     # Expose all methods as singleton
-    self.extend
-    # Initialize actor proxy and return it
+    begin
+      self.extend
+    rescue => e
+      # TODO: log failure
+    end
     proxy = Celluloid::Actor.new(self, actor_options).proxy
     proxy._send_(:initialize)
     return proxy


### PR DESCRIPTION
This commit adds Cellulate, a mixin which can be used to convert
an existing object into a Celluloid Actor proxy.

Either mix in, or extend your object with Cellulate and assign it
the result of its own "cellulate" call. See cellulate.rb in
examples for code sample.

TODO:
testing
create Cellulate::IO and DCellulate for the corresponding
libraries.
