### PR TITLE
Avoid manual emulation of public dispatch by using public_send

### DIFF
--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -7,32 +7,6 @@ module Celluloid
       @method, @arguments, @block = method, arguments, block
     end
 
-    def check_signature(obj)
-      unless obj.respond_to? @method
-        raise NoMethodError, "undefined method `#{@method}' for #{obj.to_s}"
-      end
-
-      begin
-        arity = obj.method(@method).arity
-      rescue NameError
-        # If the object claims it responds to a method, but it doesn't exist,
-        # then we have to assume method_missing will do what it says
-        @arguments.unshift(@method)
-        @method = :method_missing
-        return
-      end
-
-      if arity >= 0
-        if arguments.size != arity
-          raise ArgumentError, "wrong number of arguments (#{arguments.size} for #{arity}) for method #{@method}"
-        end
-      elsif arity < -1
-        mandatory_args = -arity - 1
-        if arguments.size < mandatory_args
-          raise ArgumentError, "wrong number of arguments (#{arguments.size} for #{mandatory_args}) for method #{@method}"
-        end
-      end
-    end
   end
 
   # Synchronous calls wait for a response
@@ -46,31 +20,16 @@ module Celluloid
     end
 
     def dispatch(obj)
-      begin
-        check_signature(obj)
-      rescue => ex
-        respond ErrorResponse.new(self, AbortError.new(ex))
-        return
-      end
-
-      begin
-        result = obj.send @method, *@arguments, &@block
-      rescue Exception => exception
-        # Exceptions that occur during synchronous calls are reraised in the
-        # context of the caller
-        respond ErrorResponse.new(self, exception)
-
-        if exception.is_a? AbortError
-          # Aborting indicates a protocol error on the part of the caller
-          # It should crash the caller, but the exception isn't reraised
-          return
-        else
-          # Otherwise, it's a bug in this actor and should be reraised
-          raise exception
-        end
-      end
-
+      result = obj.public_send(@method, *@arguments, &@block)
       respond SuccessResponse.new(self, result)
+    rescue Exception => ex
+      # Exceptions that occur during synchronous calls are reraised in the
+      # context of the caller
+      respond ErrorResponse.new(self, ex)
+      # Aborting indicates a protocol error on the part of the caller
+      # It should crash the caller, but the exception isn't reraised
+      # Otherwise, it's a bug in this actor and should be reraised
+      ex.is_a?(AbortError) ? nil : raise
     end
 
     def cleanup
@@ -84,23 +43,19 @@ module Celluloid
       # It's possible the caller exited or crashed before we could send a
       # response to them.
     end
+
   end
 
   # Asynchronous calls don't wait for a response
   class AsyncCall < Call
+
     def dispatch(obj)
-      begin
-        check_signature(obj)
-      rescue Exception => ex
-        Logger.crash("#{obj.class}: async call `#{@method}' failed!", ex)
-        return
-      end
-
-      obj.send(@method, *@arguments, &@block)
-    rescue AbortError => ex
+      obj.public_send(@method, *@arguments, &@block)
+    rescue Exception => ex
       # Swallow aborted async calls, as they indicate the caller made a mistake
-      Logger.crash("#{obj.class}: async call `#{@method}' aborted!", ex.cause)
+      Logger.crash("#{obj.class}: async call `#@method` aborted!", ex.cause)
     end
-  end
-end
 
+  end
+
+end


### PR DESCRIPTION
This simply replaces the check_signature+dispatch code with simpler code which relies directly on Ruby's public_send. It's faster in all the cases I've checked on MRI and JRuby (on par with or sometimes better than an unchecked send). My Rubinius build is stale but I'll check back with any problems once it's done building.

It's hard to benchmark with the ips suite since the async calls need a sink to check the real overhead. Specs should be green and manual testing shows no performance regressions. I don't recommend using the benchmark/actor.rb to check performance as the async calls will mess other iterations and doesn't really count the actual dispatch, just the enqueuing of the message.
