### PR TITLE
Fixed handling non-AbortError errors in async call

### DIFF
--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -51,9 +51,9 @@ module Celluloid
 
     def dispatch(obj)
       obj.public_send(@method, *@arguments, &@block)
-    rescue Exception => ex
+    rescue AbortError => ex
       # Swallow aborted async calls, as they indicate the caller made a mistake
-      Logger.crash("#{obj.class}: async call `#@method` aborted!", ex.cause)
+      Logger.debug("#{obj.class}: async call `#@method` aborted!\n#{Logger.format_exception(ex.cause)}")
     end
 
   end


### PR DESCRIPTION
The current way errors are handled in async calls will leave a confusing NoMethodError "cause" because it catches every exception, and not just AbortErrors. And only AbortErrors respond to `cause`.

A quick example of a missing method error that this pull request fixes:

```
class Foo
    include Celluloid
 end

foo = Foo.new
foo.async.bar
```

Will trigger a _NoMethodError: undefined method 'cause' for #NoMethodError:0x53c60f74_ error, rather than reporting that the method `bar` doesn't exist.

Pull request will fix it so in this case, it would respond with _NoMethodError: undefined method `bar' for #Celluloid::Actor(Foo:0xc21)_
