### PR TITLE
Added total_busy and total_idle stat calls for the pool manager

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -80,6 +80,14 @@ module Celluloid
       @size
     end
 
+    def busy_size
+      @busy.length
+    end
+
+    def idle_size
+      @idle.length
+    end
+
     # Provision a new worker
     def __provision_worker
       while @idle.empty?


### PR DESCRIPTION
Currently, the only way you can determine total idle and busy is to manually keep track of it via callbacks. Which starts to become a bit of a hack to deal with, since then you have to account for crashed workers. Especially when there is an alternative of just getting the length of the `busy` and `idle` arrays.

Perhaps this change isn't of interest, but the examples given on the wiki are of using pools for background workers, where being able to get info on idle/busy is very useful. Due to the use of `method_missing` by the pool manager, the only way to get access to these stats in is by a method added to the class itself.
