### PR TITLE
[BUG] Actors cannot override #send

### DIFF
--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -222,6 +222,11 @@ shared_context "a Celluloid Actor" do |included_module|
     actor.wrapped_object.inspect.should include Celluloid::BARE_OBJECT_WARNING_MESSAGE
   end
 
+  it "can override #send" do
+    actor = actor_class.new "Troy McClure"
+    actor.send('foo').should == 'oof'
+  end
+
   context "mocking methods" do
     let(:actor) { actor_class.new "Troy McClure" }
 

--- a/spec/support/example_actor_class.rb
+++ b/spec/support/example_actor_class.rb
@@ -56,6 +56,10 @@ module ExampleActorClass
         inspect
       end
 
+      def send(string)
+        string.reverse
+      end
+
       def method_missing(method_name, *args, &block)
         if delegates?(method_name)
           @delegate.send method_name, *args, &block


### PR DESCRIPTION
Regression because of use of #public_send
