### PR TITLE
Protect FSM transition methods

### DIFF
--- a/lib/celluloid/fsm.rb
+++ b/lib/celluloid/fsm.rb
@@ -76,6 +76,8 @@ module Celluloid
     end
     alias_method :actor=, :attach
 
+    protected
+
     # Transition to another state
     # Options:
     # * delay: don't transition immediately, wait the given number of seconds.
@@ -98,8 +100,6 @@ module Celluloid
     def transition!(state_name)
       @state = state_name
     end
-
-    protected
 
     def validate_and_sanitize_new_state(state_name)
       state_name = state_name.to_sym

--- a/spec/celluloid/fsm_spec.rb
+++ b/spec/celluloid/fsm_spec.rb
@@ -38,13 +38,17 @@ describe Celluloid::FSM do
 
   it "transitions between states" do
     subject.state.should_not == :done
-    subject.transition :done
+    subject.send :transition, :done
     subject.state.should == :done
+  end
+
+  it "does not allow other objects to transition states" do
+    expect { subject.transition :done }.to raise_error NoMethodError
   end
 
   it "fires callbacks for states" do
     subject.should_not be_fired
-    subject.transition :callbacked
+    subject.send :transition, :callbacked
     subject.should be_fired
   end
 
@@ -53,16 +57,16 @@ describe Celluloid::FSM do
   end
 
   it "supports constraints on valid state transitions" do
-    subject.transition :pre_done
-    expect { subject.transition :another }.to raise_exception ArgumentError
+    subject.send :transition, :pre_done
+    expect { subject.send :transition, :another }.to raise_exception ArgumentError
   end
 
   it "transitions to states after a specified delay" do
     interval = Celluloid::TIMER_QUANTUM * 10
 
     subject.attach DummyActor.new
-    subject.transition :another
-    subject.transition :done, :delay => interval
+    subject.send :transition, :another
+    subject.send :transition, :done, :delay => interval
 
     subject.state.should == :another
     sleep interval + Celluloid::TIMER_QUANTUM
@@ -74,11 +78,11 @@ describe Celluloid::FSM do
     interval = Celluloid::TIMER_QUANTUM * 10
 
     subject.attach DummyActor.new
-    subject.transition :another
-    subject.transition :done, :delay => interval
+    subject.send :transition, :another
+    subject.send :transition, :done, :delay => interval
 
     subject.state.should == :another
-    subject.transition :pre_done
+    subject.send :transition, :pre_done
     sleep interval + Celluloid::TIMER_QUANTUM
 
     subject.state.should == :pre_done
@@ -89,7 +93,7 @@ describe Celluloid::FSM do
 
     context "transition is delayed" do
       it "raises an unattached error" do
-        expect { subject.transition :another, :delay => 100 } \
+        expect { subject.send :transition, :another, :delay => 100 } \
           .to raise_error(Celluloid::FSM::UnattachedError)
       end
     end
@@ -99,12 +103,12 @@ describe Celluloid::FSM do
     let(:subject) { TestMachine.new }
 
     it "raises an argument error" do
-      expect { subject.transition :invalid_state }.to raise_error(ArgumentError)
+      expect { subject.send :transition, :invalid_state }.to raise_error(ArgumentError)
     end
 
     it "should not call transition! if the state is :default" do
       subject.should_not_receive :transition!
-      subject.transition :default
+      subject.send :transition, :default
     end
   end
 end


### PR DESCRIPTION
In most cases, the state machine should be included into the object transitioning, instead of being a separate class/object.

e.g. in the cigarette_smokers example:

``` rb
class Smoker
  include Celluloid

  class Machine
    include Celluloid::FSM

    default_state :standing
  end

  def initialize
    @machine = Machine.new
    ...
```

I'd prefer to do:

``` rb
class Smoker
  include Celluloid
  include Celluloid::FSM

  default_state :standing
  ...
```

If there is a need to transition a state machine from outside of the object, we should encourage users to define verbs on the state machine that represent events, and the state machine should decide to transition based on those events. 

Just my opinion, curious to know your thoughts…
