### PR TITLE
Lower shutdown timeout to 10 seconds and print warning

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -8,7 +8,7 @@ module Celluloid
   extend self # expose all instance methods as singleton methods
 
   # How long actors have to terminate
-  SHUTDOWN_TIMEOUT = 120
+  SHUTDOWN_TIMEOUT = 10
 
   # Warning message added to Celluloid objects accessed outside their actors
   BARE_OBJECT_WARNING_MESSAGE = "WARNING: BARE CELLULOID OBJECT "
@@ -86,6 +86,8 @@ module Celluloid
 
         Logger.debug "Shutdown completed cleanly"
       end
+    rescue Timeout::Error => ex
+      Logger.error("Couldn't cleanly terminate all actors in #{SHUTDOWN_TIMEOUT} seconds!")
     end
   end
 


### PR DESCRIPTION
Many people have complained about being unable to terminate Celluloid
programs with ^C and so forth when Celluloid is not able to cleanly
shut down all actors.

Celluloid has a built-in failsafe for this, but it does not kick in
until after 120 seconds! Lowering this failsafe time should make it
easier for people who are having trouble shutting down Celluloid-based
programs at the risk that there are reasonable circumstances under which
10 seconds isn't enough.
