### PR TITLE
Terminate supervision group members in reverse order

### DIFF
--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -90,7 +90,7 @@ module Celluloid
 
     # Terminate the group
     def finalize
-      @members.each(&:terminate)
+      @members.reverse_each(&:terminate)
     end
 
     # Restart a crashed actor


### PR DESCRIPTION
When starting a group of actors in the order defined, I expected them to shut down in reverse order, so that ordered dependencies continue to function properly.
