### PR TITLE
do not call actor for inspect and hash identity

### DIFF
--- a/lib/celluloid/proxies/actor_proxy.rb
+++ b/lib/celluloid/proxies/actor_proxy.rb
@@ -4,6 +4,16 @@ module Celluloid
   class ActorProxy
     attr_reader :mailbox, :thread
 
+    protected
+    def __klass__
+      @class
+    end
+
+    def __subject_id__
+      @subject_id
+    end
+    public
+
     def initialize(actor)
       @mailbox, @thread, @klass = actor.mailbox, actor.thread, actor.subject.class.to_s
       @subject_id = actor.subject.object_id
@@ -25,6 +35,19 @@ module Celluloid
 
     def _send_(meth, *args, &block)
       Actor.call @mailbox, :__send__, meth, *args, &block
+    end
+
+    # Return persistent hash key
+    # Does not call actor.
+    def hash
+      __subject_id__
+    end
+
+    # Equality for ActorProxies
+    # Returns true if both proxies point to the same actor.
+    # Does not call actor.
+    def eql?(other)
+      other.__class__ == __class__ && __klass__ == other.__klass__ && __subject_id__ == other.__subject_id__
     end
 
     # Inspect this proxy (not actor).

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -21,8 +21,23 @@ shared_context "a Celluloid Actor" do |included_module|
 
   it "can be stored in hashes" do
     actor = actor_class.new "Troy McClure"
+    actor2 = actor_class.new "Blocky Ralboa"
     actor.hash.should_not == Kernel.hash
     actor.object_id.should_not == Kernel.object_id
+
+    actor.should eql actor
+    actor.should_not eql actor2
+
+    actor.hash.should == actor.hash
+    actor.hash.should_not == actor2.hash
+
+    actor.terminate
+
+    actor.should eql actor
+    actor.should_not eql actor2
+
+    actor.hash.should == actor.hash
+    actor.hash.should_not == actor2.hash
   end
 
   it "supports synchronous calls" do


### PR DESCRIPTION
Hello Tony,

thanks a lot for celluloid and celluloid-io!

I am currently using it for developing a benchmarking framework. For this I needed to make a couple of changes. While debugging my application I ran into problems where inspecting the actor proxies created infinite loops until I commented out the call to the actor in ActorProxy#inspect and only show information local to the proxy. At this, I also found it insightful while debugging to see my object is actually an ActorProxy, not an actor.

In a similar vein, I found it practical to be able to put actor proxies into a Hash. For this to work in the case where actors may die, the identity information should not be queried from the actors. Using local information is also much faster, especially when the actors are busy. This also enables me to see in trap_exit which particular actor died more than just its class.

Best regards,
Philipp
