### PR TITLE
Exclusive method and ExitEvent problem

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -415,7 +415,7 @@ module Celluloid
 
     # Run a method inside a task unless it's exclusive
     def task(task_type, method_name = nil, &block)
-      if @exclusives && (@exclusives == :all || @exclusives.include?(method_name.to_sym))
+      if @exclusives && (@exclusives == :all || (method_name && @exclusives.include?(method_name.to_sym)))
         exclusive { block.call }
       else
         @task_class.new(task_type, &block).resume


### PR DESCRIPTION
If an Actor specifies an individual exclusive method (as opposed to the entire Actor being exclusive) then it is possible for the following error to occur when the Actor is sent an an ExitEvent:

```
E, [2013-02-18T12:06:21.054599 #28539] ERROR -- : #<Class:0x007f9663acff48> crashed! NoMethodError: undefined method `to_sym' for nil:NilClass
 ~/celluloid/lib/celluloid/actor.rb:423:in `task'
 ~/celluloid/lib/celluloid/actor.rb:341:in `handle_system_event'
 ~/celluloid/lib/celluloid/actor.rb:326:in `handle_message'
 ~/celluloid/lib/celluloid/actor.rb:195:in `run'
 ~/celluloid/lib/celluloid/actor.rb:183:in `block in initialize'
 ~/celluloid/lib/celluloid/thread_handle.rb:12:in `block in initialize'
 ~/celluloid/lib/celluloid/internal_pool.rb:55:in `call'
 ~/celluloid/lib/celluloid/internal_pool.rb:55:in `block in create'
```

I am running into this issue when I have a supervised Actor that creates another Actor with new_link. If an exception is raised causing the Actors to shutdown the above stack trace shows up in the logs. 

I attempted to add a unit test showing that this was fixed, but I was unable to put together a good test case for this.

Thanks.
