### PR TITLE
Better cpu counter on Linux

### DIFF
--- a/lib/celluloid/cpu_counter.rb
+++ b/lib/celluloid/cpu_counter.rb
@@ -6,7 +6,11 @@ module Celluloid
     when 'darwin'
       @cores = Integer(`sysctl hw.ncpu`[/\d+/])
     when 'linux'
-      @cores = File.read("/proc/cpuinfo").scan(/(?:core id|processor)\s+: \d+/).uniq.size
+      @cores = if File.exists?("/sys/devices/system/cpu/present")
+        File.read("/sys/devices/system/cpu/present").split('-').last.to_i+1
+      else
+        Dir["/sys/devices/system/cpu/cpu*"].select { |n| n=~/cpu\d+/ }.count
+      end
     when 'mingw', 'mswin'
       @cores = Integer(`SET NUMBER_OF_PROCESSORS`[/\d+/])
     else
@@ -16,3 +20,5 @@ module Celluloid
     def self.cores; @cores; end
   end
 end
+
+


### PR DESCRIPTION
As talked about in https://github.com/celluloid/celluloid/issues/171, this does a better job of determining cpu count on Linux.

Of course, I haven't been able to test this on anything but Debian and Ubuntu. I know this should work on RedHat as well and they seem to do something similar in libvirt.
