### PR TITLE
Unify suspend in Actor.call and Actor#sleep into Celluloid.suspend

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -47,11 +47,11 @@ module Celluloid
       Logger.exception_handler(&block)
     end
 
-    def suspend(waiter)
+    def suspend(status, waiter)
       task = Thread.current[:celluloid_task]
       if task && !Celluloid.exclusive?
         waiter.before_suspend(task) if waiter.respond_to?(:before_suspend)
-        Task.suspend(waiter.suspend_status)
+        Task.suspend(status)
       else
         waiter.wait
       end

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -66,7 +66,7 @@ module Celluloid
           raise DeadActorError, "attempted to call a dead actor"
         end
 
-        Celluloid.suspend(call).value
+        Celluloid.suspend(:callwait, call).value
       end
 
       # Invoke a method asynchronously on an actor via its mailbox
@@ -302,10 +302,6 @@ module Celluloid
         @interval = interval
       end
 
-      def suspend_status
-        :sleeping
-      end
-
       def before_suspend(task)
         @timers.after(@interval) { task.resume }
       end
@@ -318,7 +314,7 @@ module Celluloid
     # Sleep for the given amount of time
     def sleep(interval)
       sleeper = Sleeper.new(@timers, interval)
-      Celluloid.suspend(sleeper)
+      Celluloid.suspend(:sleeping, sleeper)
     end
 
     # Handle standard low-priority messages

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -35,10 +35,6 @@ module Celluloid
       raise
     end
 
-    def suspend_status
-      :callwait
-    end
-
     def wait
       loop do
         message = Thread.mailbox.receive do |msg|


### PR DESCRIPTION
I found that there was a pattern in 2 places where the ability to suspend the current Task is checked and then 1 of 2 different things were executed. 

This unifies the pattern and allows for an object to tell Celluloid how to behave depending on whether it is allowed to suspend or not. 
