### PR TITLE
Add a noop implementation of class method for changing block execution

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -216,6 +216,12 @@ module Celluloid
       end
     end
 
+    # Mark methods as running blocks on the receiver
+    def execute_block_on_receiver(*methods)
+      # A noop method in preparation
+      # See https://github.com/celluloid/celluloid/pull/55
+    end
+
     # Configuration options for Actor#new
     def actor_options
       {


### PR DESCRIPTION
As part of the change in #55, we are adding a method for declaratively changing whether methods run their blocks in the sending or receiving actor. 

This change allows libraries to start specifying this before the change is merged. 

@tarcieri, could we decide on the method name at this point?
Are you happy with my choice?
