### PR TITLE
Shutdown and boot Celluloid for each example to prevent Thread explosion

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -57,6 +57,13 @@ module Celluloid
       end
     end
 
+    # Launch default services
+    # FIXME: We should set up the supervision hierarchy here
+    def boot
+      Celluloid::Notifications::Fanout.supervise_as :notifications_fanout
+      Celluloid::IncidentReporter.supervise_as :default_incident_reporter, STDERR
+    end
+
     # Shut down all running actors
     def shutdown
       Timeout.timeout(shutdown_timeout) do

--- a/lib/celluloid/boot.rb
+++ b/lib/celluloid/boot.rb
@@ -9,10 +9,7 @@ end
 
 Celluloid.logger     = Logger.new(STDERR)
 
-# Launch default services
-# FIXME: We should set up the supervision hierarchy here
-Celluloid::Notifications::Fanout.supervise_as :notifications_fanout
-Celluloid::IncidentReporter.supervise_as :default_incident_reporter, STDERR
+Celluloid.boot
 
 # Terminate all actors at exit
 at_exit do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,9 @@ Dir['./spec/support/*.rb'].map {|f| require f }
 RSpec.configure do |config|
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
+
+  config.before do |example|
+    Celluloid.shutdown
+    Celluloid.boot
+  end
 end


### PR DESCRIPTION
This helps when debugging as you know that the Threads/Actors are
related to the current example.

This might make the tests slower. 
