### PR TITLE
TaskThread does not raise exceptions outside

### DIFF
--- a/spec/support/task_examples.rb
+++ b/spec/support/task_examples.rb
@@ -33,4 +33,13 @@ shared_context "a Celluloid Task" do |task_class|
     subject.should_not be_running
   end
 
+  it "raises exceptions outside" do
+    task = task_class.new(task_type) do
+      raise "failure"
+    end
+    expect do
+      task.resume
+    end.to raise_exception("failure")
+  end
+
 end


### PR DESCRIPTION
This will be the cause of many problems. 
One result is the actor not dying when a method call raises an exception. 
