### PR TITLE
Why is SHUTDOWN_TIMEOUT a constant?

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -10,9 +10,10 @@ module Celluloid
   BARE_OBJECT_WARNING_MESSAGE = "WARNING: BARE CELLULOID OBJECT "
 
   class << self
-    attr_accessor :internal_pool # Internal thread pool
-    attr_accessor :logger        # Thread-safe logger class
-    attr_accessor :task_class    # Default task type to use
+    attr_accessor :internal_pool    # Internal thread pool
+    attr_accessor :logger           # Thread-safe logger class
+    attr_accessor :task_class       # Default task type to use
+    attr_accessor :shutdown_timeout # How long actors have to terminate
 
     def included(klass)
       klass.send :extend,  ClassMethods
@@ -92,11 +93,6 @@ module Celluloid
       end
     rescue Timeout::Error => ex
       Logger.error("Couldn't cleanly terminate all actors in #{shutdown_timeout} seconds!")
-    end
-
-    # How long actors have to terminate
-    def shutdown_timeout
-      10
     end
   end
 

--- a/lib/celluloid/boot.rb
+++ b/lib/celluloid/boot.rb
@@ -3,6 +3,7 @@
 # Configure default systemwide settings
 Celluloid.task_class = Celluloid::TaskFiber
 Celluloid.logger     = Logger.new(STDERR)
+Celluloid.shutdown_timeout = 10
 
 Celluloid.boot
 


### PR DESCRIPTION
Shouldn't this be configurable by user code instead of being constant (will get warning if redefined)?
