### PR TITLE
PoolManager respond_to issues

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -113,7 +113,7 @@ module Celluloid
       signal :respawn_complete
     end
 
-    def respond_to?(method)
+    def respond_to?(method, include_private = false)
       super || @worker_class.instance_methods.include?(method.to_sym)
     end
 


### PR DESCRIPTION
```
irb(main):001:0> class FakeWorker
irb(main):002:1>   include Celluloid
irb(main):003:1> end
=> FakeWorker
irb(main):004:0> Celluloid::Actor[:crazy_queue] = FakeWorker.pool
=> #<Celluloid::Actor(FakeWorker:0x3fd5944d6684)>
irb(main):005:0> Celluloid::Actor[:crazy_queue].respond_to?(:async)
E, [2013-01-19T14:25:27.190913 #8253] ERROR -- : Celluloid::PoolManager crashed!
ArgumentError: wrong number of arguments (2 for 1)
/Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/pool_manager.rb:115:in `respond_to?'
/Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `public_send'
/Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `dArgumentErrorispatch'
/Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/actor.rb:327:in `block in handle_message'
/Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/tasks/task_fiber.rb:24:in `block in initialize'
: wrong number of arguments (2 for 1)
    from /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/pool_manager.rb:115:in `respond_to?'
    from /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `public_send'
    from /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `dispatch'
    from /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/actor.rb:327:in `block in handle_message'
    from /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/celluloid-0.12.4/lib/celluloid/tasks/task_fiber.rb:24:in `block in initialize'
irb(main):006:0> 
```

The referenced line only has 1 args. Am i missing something?

``` Ruby
    def respond_to?(method)
      super || @worker_class.instance_methods.include?(method.to_sym)
    end
```
