### PR TITLE
Add accessor for Mailbox messages

### DIFF
--- a/lib/celluloid/mailbox.rb
+++ b/lib/celluloid/mailbox.rb
@@ -12,6 +12,9 @@ module Celluloid
     # A unique address at which this mailbox can be found
     attr_reader :address
 
+    # Access messages in mailbox
+    attr_reader :messages
+
     def initialize
       @address   = Celluloid.uuid
       @messages  = []

--- a/spec/support/mailbox_examples.rb
+++ b/spec/support/mailbox_examples.rb
@@ -3,6 +3,7 @@ shared_context "a Celluloid Mailbox" do
     message = :ohai
 
     subject << message
+    subject.messages.size.should == 1
     subject.receive.should == message
   end
 


### PR DESCRIPTION
I understand if you don't want to add this, however, I maintain https://github.com/brandonhilkert/sucker_punch and getting at existing queue sizes would be a helpful addition, rather than having to monkey patch the `Mailbox` class in the gem. (re: https://github.com/brandonhilkert/sucker_punch/issues/11)
