### PR TITLE
Celluloid.name raises

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -271,6 +271,11 @@ module Celluloid
       current_actor
     end
 
+    # Obtain the name of the current actor
+    def name
+      Actor.name
+    end
+
     def inspect
       str = "#<"
 
@@ -330,11 +335,6 @@ module Celluloid
   # Obtain the UUID of the current call chain
   def call_chain_id
     Thread.current[:celluloid_chain_id]
-  end
-
-  # Obtain the name of the current actor
-  def name
-    Actor.name
   end
 
   # Obtain the running tasks for this actor


### PR DESCRIPTION
```
> Celluloid.name
Celluloid::NotActorError: not in actor scope
    from /home/kostya/.rvm/gems/ruby-2.0.0-p0/gems/celluloid-0.13.0/lib/celluloid/actor.rb:55:in `name'
    from /home/kostya/.rvm/gems/ruby-2.0.0-p0/gems/celluloid-0.13.0/lib/celluloid.rb:331:in `name'
```

it breaks new statemachine gem 1.2
