### PR TITLE
Share lots more code between TaskFiber and TaskThread

### DIFF
--- a/lib/celluloid/tasks/task_fiber.rb
+++ b/lib/celluloid/tasks/task_fiber.rb
@@ -3,52 +3,20 @@ module Celluloid
 
   # Tasks with a Fiber backend
   class TaskFiber < Task
-    attr_reader :type, :status
 
-    # Run the given block within a task
-    def initialize(type)
-      super
-
-      actor    = Thread.current[:celluloid_actor]
-      mailbox  = Thread.current[:celluloid_mailbox]
-      chain_id = Thread.current[:celluloid_chain_id]
-
-      raise NotActorError, "can't create tasks outside of actors" unless actor
-
+    def create
       @fiber = Fiber.new do
-        @status = :running
-        Thread.current[:celluloid_actor]    = actor
-        Thread.current[:celluloid_mailbox]  = mailbox
-        Thread.current[:celluloid_task]     = self
-        Thread.current[:celluloid_chain_id] = chain_id
-
-        actor.tasks << self
-
-        begin
-          yield
-        rescue Task::TerminatedError
-          # Task was explicitly terminated
-        ensure
-          @status = :dead
-          actor.tasks.delete self
-        end
+        yield
       end
     end
 
-    # Suspend the current task, changing the status to the given argument
-    def suspend(status)
-      @status = status
-      result = Fiber.yield
-      raise result if result.is_a?(Task::TerminatedError)
-      @status = :running
-
-      result
+    def signal
+      Fiber.yield
     end
 
     # Resume a suspended task, giving it a value to return if needed
-    def resume(value = nil)
+    def deliver(value)
       @fiber.resume value
-      nil
     rescue SystemStackError => ex
       raise FiberStackError, "#{ex} (please see https://github.com/celluloid/celluloid/wiki/Fiber-stack-errors)"
     rescue FiberError => ex
@@ -57,17 +25,9 @@ module Celluloid
 
     # Terminate this task
     def terminate
-      resume Task::TerminatedError.new("task was terminated") if @fiber.alive?
+      super
     rescue FiberError
       # If we're getting this the task should already be dead
-    end
-
-    # Is the current task still running?
-    def running?; @fiber.alive?; end
-
-    # Nicer string inspect for tasks
-    def inspect
-      "<Celluloid::TaskFiber:0x#{object_id.to_s(16)} @type=#{@type.inspect}, @status=#{@status.inspect}>"
     end
   end
 end

--- a/lib/celluloid/tasks/task_thread.rb
+++ b/lib/celluloid/tasks/task_thread.rb
@@ -1,62 +1,37 @@
 module Celluloid
   # Tasks with a Thread backend
   class TaskThread < Task
-    attr_reader :type, :status
-
     # Run the given block within a task
     def initialize(type)
-      super
-
       @resume_queue = Queue.new
       @exception_queue = Queue.new
       @yield_mutex  = Mutex.new
       @yield_cond   = ConditionVariable.new
 
-      actor    = Thread.current[:celluloid_actor]
-      mailbox  = Thread.current[:celluloid_mailbox]
-      chain_id = Thread.current[:celluloid_chain_id]
+      super
+    end
 
-      raise NotActorError, "can't create tasks outside of actors" unless actor
-
+    def create
       @thread = Celluloid.internal_pool.get do
         begin
           ex = @resume_queue.pop
           raise ex if ex.is_a?(Task::TerminatedError)
 
-          @status = :running
-          Thread.current[:celluloid_actor]    = actor
-          Thread.current[:celluloid_mailbox]  = mailbox
-          Thread.current[:celluloid_task]     = self
-          Thread.current[:celluloid_chain_id] = chain_id
-
-          actor.tasks << self
           yield
-        rescue Task::TerminatedError
-          # Task was explicitly terminated
         rescue Exception => ex
           @exception_queue << ex
         ensure
-          @status = :dead
-          actor.tasks.delete self
           @yield_cond.signal
         end
       end
     end
 
-    # Suspend the current task, changing the status to the given argument
-    def suspend(status)
-      @status = status
+    def signal
       @yield_cond.signal
-      value = @resume_queue.pop
-
-      raise value if value.is_a?(Task::TerminatedError)
-      @status = :running
-
-      value
+      @resume_queue.pop
     end
 
-    # Resume a suspended task, giving it a value to return if needed
-    def resume(value = nil)
+    def deliver(value)
       raise DeadTaskError, "cannot resume a dead task" unless @thread.alive?
 
       @yield_mutex.synchronize do
@@ -66,23 +41,8 @@ module Celluloid
           raise @exception_queue.pop
         end
       end
-
-      nil
     rescue ThreadError
       raise DeadTaskError, "cannot resume a dead task"
-    end
-
-    # Terminate this task
-    def terminate
-      resume Task::TerminatedError.new("task was terminated") if @thread.alive?
-    end
-
-    # Is the current task still running?
-    def running?; @status != :dead; end
-
-    # Nicer string inspect for tasks
-    def inspect
-      "<Celluloid::TaskThread:0x#{object_id.to_s(16)} @type=#{@type.inspect}, @status=#{@status.inspect}>"
     end
   end
 end


### PR DESCRIPTION
Code re-use is good. 
I wanted to have a sane superclass, so here it is. 

I don't really like the subclass interface methods. `#signal` and `#deliver`. 
