### PR TITLE
External Shutdown Does Not Complete

### DIFF
--- a/lib/celluloid/thread_handle.rb
+++ b/lib/celluloid/thread_handle.rb
@@ -32,6 +32,7 @@ module Celluloid
 
     # Join to a running thread, blocking until it terminates
     def join
+      raise ThreadError, "Target thread must not be current thread" if @thread == Thread.current
       @mutex.synchronize { @join.wait(@mutex) if @thread }
       self
     end


### PR DESCRIPTION
When terminating actors externally, they seem to "stop what they're doing" but they don't return, which can prevent further code from running.

Note: This is on JRuby `1.7.2` and Celluloid `0.12.4`.

The following example kills the loop as expected, but it never returns:

``` ruby
class LOL
  include Celluloid

  def run
    loop { puts "run loop"; sleep 0.1 }
  end  
end  

l = LOL.new
l.after(3) { l.terminate }
l.run
puts "…"
```

Whereas calling `#terminate` internally functions as expected:

``` ruby
class LOL
  include Celluloid

  def run
    after(3) { terminate }
    loop { puts "run loop"; sleep 0.1 }
  end  
end  

l = LOL.new
l.run
puts "…"
```
