### PR TITLE
InternalPool doesn't clean up at_exit

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -73,6 +73,8 @@ module Celluloid
     # Shut down all running actors
     def shutdown
       Timeout.timeout(shutdown_timeout) do
+        internal_pool.shutdown
+
         actors = Actor.all
         Logger.debug "Terminating #{actors.size} actors..." if actors.size > 0
 

--- a/lib/celluloid/internal_pool.rb
+++ b/lib/celluloid/internal_pool.rb
@@ -74,6 +74,15 @@ module Celluloid
         thread[key] = nil
       end
     end
+
+    def shutdown
+      @mutex.synchronize do
+        @max_idle = 0
+        @pool.each do |thread|
+          thread[:celluloid_queue] << nil
+        end
+      end
+    end
   end
 
   self.internal_pool = InternalPool.new


### PR DESCRIPTION
Any threads from the InternalPool that aren't currently allocated to actors will block forever, causing JRuby runtimes to be retained in hot deployment environments.  The problematic line appears to be (from 0.13.0):

https://github.com/celluloid/celluloid/blob/bcff8ec7f8d77a9a51c314c35578654095c64a70/lib/celluloid/internal_pool.rb#L53
