### PR TITLE
Show the backtrace for all threads in stack_dump

### DIFF
--- a/lib/celluloid/stack_dump.rb
+++ b/lib/celluloid/stack_dump.rb
@@ -1,7 +1,7 @@
 module Celluloid
   class StackDump
 
-    class TaskState < Struct.new(:task_class, :status)
+    class TaskState < Struct.new(:task_class, :status, :backtrace)
     end
 
     class ActorState
@@ -42,7 +42,7 @@ module Celluloid
         state.status = :idle
       else
         state.status = :running
-        state.tasks = tasks.collect { |t| TaskState.new(t.class, t.status) }
+        state.tasks = tasks.collect { |t| TaskState.new(t.class, t.status, t.backtrace) }
       end
 
       state.backtrace = actor.thread.backtrace if actor.thread
@@ -62,16 +62,18 @@ module Celluloid
 
         if actor.status == :idle
           string << "State: Idle (waiting for messages)\n"
+          display_backtrace actor.backtrace, string
         else
           string << "State: Running (executing tasks)\n"
+          display_backtrace actor.backtrace, string
           string << "Tasks:\n"
 
           actor.tasks.each_with_index do |task, i|
             string << "  #{i+1}) #{task.task_class}: #{task.status}\n"
+            display_backtrace task.backtrace, string
           end
         end
 
-        display_backtrace actor.backtrace, string
         output.print string
       end
 

--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -77,6 +77,9 @@ module Celluloid
       resume Task::TerminatedError.new("task was terminated") if running?
     end
 
+    def backtrace
+    end
+
     # Is the current task still running?
     def running?; @status != :dead; end
 

--- a/lib/celluloid/tasks/task_thread.rb
+++ b/lib/celluloid/tasks/task_thread.rb
@@ -44,5 +44,9 @@ module Celluloid
     rescue ThreadError
       raise DeadTaskError, "cannot resume a dead task"
     end
+
+    def backtrace
+      @thread.backtrace
+    end
   end
 end


### PR DESCRIPTION
When using `TaskThread` we can see each of the tasks independent backtraces. 
