### PR TITLE
The lack of the at_exit handler causes hard deadlocks

### DIFF
--- a/lib/celluloid/autostart.rb
+++ b/lib/celluloid/autostart.rb
@@ -1,16 +1,3 @@
 require 'celluloid'
 
 Celluloid.boot
-
-# Terminate all actors at exit
-at_exit do
-  if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
-    # workaround for MRI bug losing exit status in at_exit block
-    # http://bugs.ruby-lang.org/issues/5218
-    exit_status = $!.status if $!.is_a?(SystemExit)
-    Celluloid.shutdown
-    exit exit_status if exit_status
-  else
-    Celluloid.shutdown
-  end
-end


### PR DESCRIPTION
If you run this: https://gist.github.com/halorgium/14465667d26e4b053180
You will get a deadlock. 

This is definitely an issue with `TaskFiber`s only as `TaskThread` behaves correctly. 

We either need to add the `at_exit` handler back or get to the root cause. 
