### PR TITLE
Actor-local Celluloid::Thread#[] support

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -27,7 +27,7 @@ module Celluloid
   # normal Ruby objects wrapped in threads which communicate with asynchronous
   # messages.
   class Actor
-    attr_reader :subject, :proxy, :tasks, :links, :mailbox, :thread, :name
+    attr_reader :subject, :proxy, :tasks, :links, :mailbox, :thread, :name, :locals
 
     class << self
       extend Forwardable
@@ -151,6 +151,7 @@ module Celluloid
       @running   = true
       @exclusive = false
       @name      = nil
+      @locals    = {}
 
       @thread = ThreadHandle.new do
         setup_thread

--- a/lib/celluloid/internal_pool.rb
+++ b/lib/celluloid/internal_pool.rb
@@ -42,7 +42,7 @@ module Celluloid
         if @pool.size >= @max_idle
           thread[:celluloid_queue] << nil
         else
-          clean_thread_locals(thread)
+          thread.recycle
           @pool << thread
           @idle_size += 1
           @busy_size -= 1
@@ -67,16 +67,6 @@ module Celluloid
 
       thread[:celluloid_queue] = queue
       thread
-    end
-
-    # Clean the thread locals of an incoming thread
-    def clean_thread_locals(thread)
-      thread.keys.each do |key|
-        next if key == :celluloid_queue
-
-        # Ruby seems to lack an API for deleting thread locals. WTF, Ruby?
-        thread[key] = nil
-      end
     end
 
     def shutdown

--- a/lib/celluloid/thread.rb
+++ b/lib/celluloid/thread.rb
@@ -2,5 +2,77 @@ require 'celluloid/fiber'
 
 module Celluloid
   class Thread < ::Thread
+    # FIXME: these should be replaced using APIs on Celluloid::Thread itself
+    # e.g. Thread.current[:celluloid_actor] => Thread.current.actor
+    CELLULOID_LOCALS = [
+      :celluloid_actor,
+      :celluloid_mailbox,
+      :celluloid_queue,
+      :celluloid_task,
+      :celluloid_chain_id
+    ]
+
+    # A roundabout way to avoid purging :celluloid_queue
+    EPHEMERAL_CELLULOID_LOCALS = CELLULOID_LOCALS - [:celluloid_queue]
+
+    # Obtain the Celluloid::Actor object for this thread
+    def actor
+      self[:celluloid_actor]
+    end
+
+    # Obtain the Celluloid task object for this thread
+    def task
+      self[:celluloid_task]
+    end
+
+    # Obtain the Celluloid mailbox for this thread
+    def mailbox
+      self[:celluloid_mailbox]
+    end
+
+    # Obtain the call chain ID for this thread
+    def call_chain_id
+      self[:celluloid_chain_id]
+    end
+
+    #
+    # Override default thread local behavior, making thread locals actor-local
+    #
+
+    # Obtain an actor-local value
+    def [](key)
+      if CELLULOID_LOCALS.include?(key)
+        super(key)
+      else
+        actor = super(:celluloid_actor)
+        actor.locals[key] if actor
+      end
+    end
+
+    # Set an actor-local value
+    def []=(key, value)
+      if CELLULOID_LOCALS.include?(key)
+        super(key, value)
+      else
+        self[:celluloid_actor].locals[key] = value
+      end
+    end
+
+    # Obtain the keys to all actor-locals
+    def keys
+      actor = self[:celluloid_actor]
+      actor.locals.keys if actor
+    end
+
+    # Is the given actor local set?
+    def key?(key)
+      actor = self[:celluloid_actor]
+      actor.locals.has_key?(key) if actor
+    end
+
+    # Clear thread state so it can be reused via thread pools
+    def recycle
+      EPHEMERAL_CELLULOID_LOCALS.each { |local| self[local] = nil }
+    end
   end
 end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -323,6 +323,30 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     end
   end
 
+  context "thread locals" do
+    let(:example_class) do
+      Class.new do
+        include included_module
+        task_class task_klass
+
+        def initialize(value)
+          Thread.current[:example_thread_local] = value
+        end
+
+        def value
+          Thread.current[:example_thread_local]
+        end
+      end
+    end
+
+    let(:example_value) { "foobar" }
+
+    it "preserves thread locals between tasks" do
+      actor = example_class.new(example_value)
+      actor.value.should eq example_value
+    end
+  end
+
   context :linking do
     before :each do
       @kevin   = actor_class.new "Kevin Bacon" # Some six degrees action here


### PR DESCRIPTION
An initial spike of redirecting the methods that ordinarily deal with
Ruby thread (or, in fact, fiber) locals to a set of locals on the
Celluloid::Actor object for the current thread/fiber.

A bit of history: there existed a bunch of Ruby code which abused
Thread.current[...] as a means of achieving dynamic scope. This code
became broken when Fibers were introduced. However, rather than adding
Fiber#[] and having people who want to have pseudo-dynamic scope use
Fiber.current[...] instead of Thread.current[...], the decision was made
to make Thread.current[...] Fiber local, and for it we all suffer.

This breaks a litany of gems that use thread locals actually expecting
them to be thread local (instead of fiber local), most notably
ActiveRecord, but including any gem that tries to store a connection to
a service in a thread local.

This commit is an initial attempt to generally fix this problem
throughout Celluloid, and it's accomplished without using any core
extensions, but instead overriding the thread local behavior inside of
Celluloid::Thread (itself a subclass of Thread).

All methods for accessing thread locals are treated as "actor locals"
instead with this change, thunking to a hash stored in the
Celluloid::Actor object for the current actor.

This implementation is a bit of a hack because Celluloid has its own set
of "special" thread locals it needs to operate. It's hoped that this
commit can also provide a new set of APIs (e.g. Thread.current.actor)
which can be used to replace Celluloid's own internal usage of thread
locals, and thus help clean up Celluloid's internals at the same time.
