### PR TITLE
TaskThread marks threads as Actors incorrectly

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -78,6 +78,7 @@ module Celluloid
       def all
         actors = []
         Thread.list.each do |t|
+          next if t[:celluloid_task]
           actor = t[:celluloid_actor]
           actors << actor.proxy if actor and actor.respond_to?(:proxy)
         end

--- a/lib/celluloid/stack_dump.rb
+++ b/lib/celluloid/stack_dump.rb
@@ -25,6 +25,7 @@ module Celluloid
     def snapshot
       Thread.list.each do |thread|
         if actor = thread[:celluloid_actor]
+          next if thread[:celluloid_task]
           @actors << snapshot_actor(actor)
         else
           @threads << snapshot_thread(thread)


### PR DESCRIPTION
When using `TaskThread`, there are several issues which mean it seems like there are more actors present that there are. 

`Celluloid.stack_dump` shows N tasks + 1 actors in the output, due to thinking that a Thread is an actor only because it has the `:celluloid_actor` Thread-local. 
This also affects `Celluloid::Actor.all`. 

It should be possible to build on #224 and support querying a `Celluloid::Thread` to discover it's reason for being. 
