### PR TITLE
Add Thread#celluloid? to simplify differentiate of Threads

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -78,9 +78,9 @@ module Celluloid
       def all
         actors = []
         Thread.list.each do |t|
-          next if t[:celluloid_task]
-          actor = t[:celluloid_actor]
-          actors << actor.proxy if actor and actor.respond_to?(:proxy)
+          next unless t.celluloid?
+          next if t.task
+          actors << t.actor.proxy if t.actor && t.actor.respond_to?(:proxy)
         end
         actors
       end

--- a/lib/celluloid/core_ext.rb
+++ b/lib/celluloid/core_ext.rb
@@ -2,4 +2,8 @@ require 'celluloid/fiber'
 
 class Thread
   attr_accessor :uuid_counter, :uuid_limit
+
+  def celluloid?
+    false
+  end
 end

--- a/lib/celluloid/stack_dump.rb
+++ b/lib/celluloid/stack_dump.rb
@@ -24,9 +24,9 @@ module Celluloid
 
     def snapshot
       Thread.list.each do |thread|
-        if actor = thread[:celluloid_actor]
-          next if thread[:celluloid_task]
-          @actors << snapshot_actor(actor)
+        if thread.celluloid?
+          next if thread.task
+          @actors << snapshot_actor(thread.actor) if thread.actor
         else
           @threads << snapshot_thread(thread)
         end

--- a/lib/celluloid/thread.rb
+++ b/lib/celluloid/thread.rb
@@ -15,6 +15,10 @@ module Celluloid
     # A roundabout way to avoid purging :celluloid_queue
     EPHEMERAL_CELLULOID_LOCALS = CELLULOID_LOCALS - [:celluloid_queue]
 
+    def celluloid?
+      true
+    end
+
     # Obtain the Celluloid::Actor object for this thread
     def actor
       self[:celluloid_actor]

--- a/spec/celluloid/stack_dump_spec.rb
+++ b/spec/celluloid/stack_dump_spec.rb
@@ -7,6 +7,6 @@ describe Celluloid::StackDump do
   end
 
   it 'should include threads that are not actors' do
-    subject.threads.size.should == Thread.list.size - Celluloid::Actor.all.size
+    subject.threads.size.should == Thread.list.reject(&:celluloid?).size
   end
 end


### PR DESCRIPTION
Building on #224, this makes it easier to confirm if `Celluloid::Thread` methods are available. 
