### PR TITLE
Allow joining to an Actor with a timeout

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -129,8 +129,8 @@ module Celluloid
       end
 
       # Wait for an actor to terminate
-      def join(actor)
-        actor.thread.join
+      def join(actor, timeout = nil)
+        actor.thread.join(timeout)
         actor
       end
     end

--- a/lib/celluloid/thread_handle.rb
+++ b/lib/celluloid/thread_handle.rb
@@ -31,9 +31,9 @@ module Celluloid
     end
 
     # Join to a running thread, blocking until it terminates
-    def join
+    def join(limit = nil)
       raise ThreadError, "Target thread must not be current thread" if @thread == Thread.current
-      @mutex.synchronize { @join.wait(@mutex) if @thread }
+      @mutex.synchronize { @join.wait(@mutex, limit) if @thread }
       self
     end
 


### PR DESCRIPTION
Sometimes it is useful to only wait for a limited amount of time. 
This allows for this behaviour. 
