### PR TITLE
More forgiving thread local hacks

### DIFF
--- a/lib/celluloid/thread.rb
+++ b/lib/celluloid/thread.rb
@@ -12,9 +12,6 @@ module Celluloid
       :celluloid_chain_id
     ]
 
-    # A roundabout way to avoid purging :celluloid_queue
-    EPHEMERAL_CELLULOID_LOCALS = CELLULOID_LOCALS - [:celluloid_queue]
-
     def celluloid?
       true
     end
@@ -45,38 +42,51 @@ module Celluloid
 
     # Obtain an actor-local value
     def [](key)
-      if CELLULOID_LOCALS.include?(key)
+      actor = super(:celluloid_actor)
+      if !actor || CELLULOID_LOCALS.include?(key)
         super(key)
       else
-        actor = super(:celluloid_actor)
-        actor.locals[key] if actor
+        actor.locals[key]
       end
     end
 
     # Set an actor-local value
     def []=(key, value)
-      if CELLULOID_LOCALS.include?(key)
+      actor = self[:celluloid_actor]
+      if !actor || CELLULOID_LOCALS.include?(key)
         super(key, value)
       else
-        self[:celluloid_actor].locals[key] = value
+        actor.locals[key] = value
       end
     end
 
     # Obtain the keys to all actor-locals
     def keys
       actor = self[:celluloid_actor]
-      actor.locals.keys if actor
+      if actor
+        actor.locals.keys
+      else
+        super
+      end
     end
 
     # Is the given actor local set?
     def key?(key)
       actor = self[:celluloid_actor]
-      actor.locals.has_key?(key) if actor
+      if actor
+        actor.locals.has_key?(key)
+      else
+        super
+      end
     end
 
     # Clear thread state so it can be reused via thread pools
     def recycle
-      EPHEMERAL_CELLULOID_LOCALS.each { |local| self[local] = nil }
+      # This thread local mediates access to the others, so we must clear it first
+      self[:celluloid_actor] = nil
+
+      # Clearing :celluloid_queue would break the thread pool!
+      keys.each { |key| self[key] = nil unless key == :celluloid_queue }
     end
   end
 end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -336,6 +336,12 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
         def value
           Thread.current[:example_thread_local]
         end
+
+        def deferred_value
+          defer do
+            Thread.current[:example_thread_local]
+          end
+        end
       end
     end
 
@@ -344,6 +350,11 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     it "preserves thread locals between tasks" do
       actor = example_class.new(example_value)
       actor.value.should eq example_value
+    end
+
+    it "isolates thread locals in defer blocks" do
+      actor = example_class.new(example_value)
+      actor.deferred_value.should eq nil
     end
   end
 


### PR DESCRIPTION
This implementation should cover more corner cases (e.g. Celluloid::Future with
a block) than the previous one.

In cases where the :celluloid_actor is unset, this defers to the superclass
implementation. This allows thread local access within Celluloid::Threads even
in cases where a Celluloid::Thread is used outside an actor.
