### PR TITLE
Tasks which are terminated on actor termination do so silently

### DIFF
--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -72,7 +72,12 @@ module Celluloid
 
     # Terminate this task
     def terminate
-      resume Task::TerminatedError.new("task was terminated") if running?
+      if running?
+        Celluloid.logger.warn "Terminating task: type=#{@type.inspect}, status=#{@status.inspect}"
+        resume Task::TerminatedError.new("task was terminated")
+      else
+        raise DeadTaskError, "task is already dead"
+      end
     end
 
     def backtrace

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -308,6 +308,17 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
         actor.terminate!
       end.to raise_exception(Celluloid::DeadActorError, "actor already terminated")
     end
+
+    it "logs a warning when terminating tasks" do
+      Celluloid.logger = mock.as_null_object
+      Celluloid.logger.should_receive(:warn).with("Terminating task: type=:call, status=:sleeping")
+
+      actor = actor_class.new "Arnold Schwarzenegger"
+      actor.async.sleepy 10
+      actor.greet # make sure the actor has started sleeping
+
+      actor.terminate
+    end
   end
 
   context :current_actor do

--- a/spec/support/example_actor_class.rb
+++ b/spec/support/example_actor_class.rb
@@ -12,6 +12,10 @@ module ExampleActorClass
         @delegate = [:bar]
       end
 
+      def sleepy(duration)
+        sleep duration
+      end
+
       def change_name(new_name)
         @name = new_name
       end


### PR DESCRIPTION
``` ruby
class MyActor
  include Celluloid

  def name
    logger.info "You'll see this"
    "Foo"
  end

  def terminate_and_ask_name(other_actor)
    terminate
    other_actor.name
    logger.info "You'll never get here"
  end
end

a = MyActor.new
b = MyActor.new
a.terminate_and_ask_name b
```

The situation is this internally:
1. Terminate sets `@running` to `false`, which causes the next tick of `#receive` to terminate the actor, and therefore not listen to further responses from a `SyncCall`.
2. The `SyncCall` (`#name`) suspends the `Task` running `#terminate_and_ask_name`, which triggers the next tick of `#receive`.
3. The `SyncCall` is thus correctly dispatched to `other_actor`, but the caller never bothers to listen for the response, and so the `Task` running `#terminate_and_ask_name` is terminated.
4. Terminating the `Task` is silent: no exceptions in the calling actor, no logging and the `SyncCall` does not fail early with an exception like "You're not gonna listen to the answer so don't ask the question".

Note also that a similar thing could happen if another task terminates the calling actor while it's waiting for a response to the SyncCall.

I've discussed this a bunch with @halorgium and he thinks adding logging of unfinished `Task`s on actor termination is the appropriate way to deal with this since any more involved reasoning about how to handle such issues is too difficult to get right.
