### PR TITLE
Do not raise on mailbox errors, instead log

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -106,14 +106,14 @@ module Celluloid
         actors.each do |actor|
           begin
             actor.terminate!
-          rescue DeadActorError, MailboxError
+          rescue DeadActorError
           end
         end
 
         actors.each do |actor|
           begin
             Actor.join(actor)
-          rescue DeadActorError, MailboxError
+          rescue DeadActorError
           end
         end
 

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -122,10 +122,7 @@ module Celluloid
       # Forcibly kill a given actor
       def kill(actor)
         actor.thread.kill
-        begin
-          actor.mailbox.shutdown
-        rescue DeadActorError
-        end
+        actor.mailbox.shutdown
       end
 
       # Wait for an actor to terminate
@@ -404,10 +401,8 @@ module Celluloid
     def cleanup(exit_event)
       @mailbox.shutdown
       @links.each do |actor|
-        begin
+        if actor.mailbox.alive?
           actor.mailbox << exit_event
-        rescue MailboxError
-          # We're exiting/crashing, they're dead. Give up :(
         end
       end
 

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -86,9 +86,6 @@ module Celluloid
 
     def respond(message)
       @sender << message
-    rescue MailboxError
-      # It's possible the sender exited or crashed before we could send a
-      # response to them.
     end
 
     def value

--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -27,7 +27,7 @@ module Celluloid
       terminators = (@idle + @busy).each do |actor|
         begin
           actor.future(:terminate)
-        rescue DeadActorError, MailboxError
+        rescue DeadActorError
         end
       end
 

--- a/lib/celluloid/proxies/async_proxy.rb
+++ b/lib/celluloid/proxies/async_proxy.rb
@@ -22,14 +22,7 @@ module Celluloid
         raise "Cannot use blocks with async yet"
       end
 
-      begin
-        @mailbox << AsyncCall.new(meth, args, block)
-      rescue MailboxError
-        # Silently swallow asynchronous calls to dead actors. There's no way
-        # to reliably generate DeadActorErrors for async calls, so users of
-        # async calls should find other ways to deal with actors dying
-        # during an async call (i.e. linking/supervisors)
-      end
+      @mailbox << AsyncCall.new(meth, args, block)
     end
   end
 end

--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -149,7 +149,7 @@ module Celluloid
 
       def terminate
         @actor.terminate if @actor
-      rescue DeadActorError, MailboxError
+      rescue DeadActorError
       end
     end
   end

--- a/spec/support/mailbox_examples.rb
+++ b/spec/support/mailbox_examples.rb
@@ -63,4 +63,14 @@ shared_context "a Celluloid Mailbox" do
     subject << :second
     subject << :third
   end
+
+  it "discard messages when dead" do
+    Celluloid.logger = mock.as_null_object
+    Celluloid.logger.should_receive(:debug).with("Discarded message: third")
+
+    subject << :first
+    subject << :second
+    subject.shutdown
+    subject << :third
+  end
 end


### PR DESCRIPTION
This changes `Mailbox` to be more erlang-esque. 
A log message is generated when the mailbox is dead. 

`sync` and `future` have the same behaviour, but check before sending a message to a dead `Actor`. 

There are some erroneous log messages in the specs, but this is related to our shutdown process being non-deterministic. 
