### PR TITLE
Simplify Future to only contain messaging logic

### DIFF
--- a/examples/simple_pmap.rb
+++ b/examples/simple_pmap.rb
@@ -10,3 +10,5 @@ module Enumerable
     futures.map { |future| future.value }
   end
 end
+
+p 100.times.pmap {|n| n * 2}

--- a/lib/celluloid/future.rb
+++ b/lib/celluloid/future.rb
@@ -4,38 +4,29 @@ module Celluloid
   # Celluloid::Future objects allow methods and blocks to run in the
   # background, their values requested later
   class Future
+    def self.new(*args, &block)
+      return super unless block
+
+      future = new
+      Celluloid.internal_pool.get do
+        begin
+          call = SyncCall.new(future, :call, args)
+          call.dispatch(block)
+        rescue
+          # Exceptions in blocks will get raised when the value is retrieved
+        end
+      end
+      future
+    end
+
     attr_reader :address
-    
-    # Create a future bound to a given receiver, or with a block to compute
-    def initialize(*args, &block)
+
+    def initialize
       @address = Celluloid.uuid
       @mutex = Mutex.new
       @ready = false
       @result = nil
       @forwards = nil
-
-      if block
-        @call = SyncCall.new(self, :call, args)
-        Celluloid.internal_pool.get do
-          begin
-            @call.dispatch(block)
-          rescue
-            # Exceptions in blocks will get raised when the value is retrieved
-          end
-        end
-      else
-        @call = nil
-      end
-    end
-
-    # Execute the given method in future context
-    def execute(receiver, method, args, block)
-      @mutex.synchronize do
-        raise "already calling" if @call
-        @call = SyncCall.new(self, method, args, block)
-      end
-
-      receiver << @call
     end
 
     # Check if this future has a value yet
@@ -49,7 +40,6 @@ module Celluloid
 
       begin
         @mutex.lock
-        raise "no call requested" unless @call
 
         if @ready
           ready = true

--- a/lib/celluloid/proxies/future_proxy.rb
+++ b/lib/celluloid/proxies/future_proxy.rb
@@ -17,8 +17,16 @@ module Celluloid
         # FIXME: nicer exception
         raise "Cannot use blocks with futures yet"
       end
+
       future = Future.new
-      future.execute(@mailbox, meth, args, block)
+      call = SyncCall.new(future, meth, args, block)
+
+      begin
+        @mailbox << call
+      rescue MailboxError
+        raise DeadActorError, "attempted to call a dead actor"
+      end
+
       future
     end
   end


### PR DESCRIPTION
This means that a `Future` is simply a wrapper around waiting for a value. 
