### PR TITLE
Invalidate the block on call completion

### DIFF
--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -22,7 +22,10 @@ module Celluloid
 
     def dispatch(obj)
       _block = @block && @block.to_proc
-      obj.public_send(@method, *@arguments, &_block)
+      result = obj.public_send(@method, *@arguments, &_block)
+      # FIXME: we should only invalidate if the sender is not an actor
+      @block.invalidate if @block
+      result
     rescue NoMethodError => ex
       # Abort if the sender made a mistake
       raise AbortError.new(ex) unless obj.respond_to? @method

--- a/lib/celluloid/proxies/block_proxy.rb
+++ b/lib/celluloid/proxies/block_proxy.rb
@@ -9,9 +9,14 @@ module Celluloid
     attr_writer :execution
     attr_reader :call, :block
 
+    def invalidate
+      @invalid = true
+    end
+
     def to_proc
       if @execution == :sender
         lambda do |*values|
+          raise "The original method call has completed, the block is now invalid" if @invalid
           if task = Thread.current[:celluloid_task]
             @mailbox << BlockCall.new(self, Actor.current.mailbox, values)
             # TODO: if respond fails, the Task will never be resumed


### PR DESCRIPTION
When calling a method on an `Actor` from a normal `Thread`, if you invoke a block after the `Call` has completed, you will encounter a deadlock. 

This is due to the fact the sending `Thread` is no longer waiting for the block invocations. 
[gist](https://gist.github.com/halorgium/5554085/ffd1a4b4f57394d0514f486517e2a4646e66f273)

If you are calling from an Actor, this behaviour works. 
[gist](https://gist.github.com/halorgium/5554085/db96cf50b7f120b22c03437d53e6d7434d1824f0)

This change invalidates the block for both scenarios. 
We can allow block invocations in the actor case by only invalidating if the sender is a normal `Thread`. 
- [ ] Specs
- [ ] Remove extra FIXMEs
- [ ] Consider async/future + blocks with respect to invalidation
