### PR TITLE
Only allow 2 exceptions to be automatically raised inside Tasks

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -461,7 +461,7 @@ module Celluloid
     bt = caller
     task = Task.current
     timer = after(duration) do
-      exception = TimeoutError.new
+      exception = Task::TimeoutError.new
       exception.set_backtrace bt
       task.resume exception
     end

--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -5,9 +5,14 @@ module Celluloid
   # Trying to resume a dead task
   class DeadTaskError < Celluloid::Error; end
 
+  # Errors which should be resumed automatically
+  class ResumableError < Celluloid::Error; end
+
   # Tasks are interruptable/resumable execution contexts used to run methods
   class Task
-    class TerminatedError < Celluloid::Error; end # kill a running task
+    class TerminatedError < ResumableError; end # kill a running task after terminate
+
+    class TimeoutError < ResumableError; end # kill a running task after timeout
 
     # Obtain the current task
     def self.current
@@ -58,7 +63,7 @@ module Celluloid
       @status = status
       value = signal
 
-      raise value if value.is_a?(Celluloid::Error)
+      raise value if value.is_a?(Celluloid::ResumableError)
       @status = :running
 
       value

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -920,11 +920,11 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
       end
     end
 
-    it "allows timing out tasks, raising Celluloid::TimeoutError" do
+    it "allows timing out tasks, raising Celluloid::Task::TimeoutError" do
       a1 = actor_class.new
       a2 = actor_class.new
 
-      expect { a1.ask_name_with_timeout a2, 0.3 }.to raise_error(Celluloid::TimeoutError)
+      expect { a1.ask_name_with_timeout a2, 0.3 }.to raise_error(Celluloid::Task::TimeoutError)
     end
 
     it "does not raise when it completes in time" do


### PR DESCRIPTION
The change minimizes the impact of #243. 

Currently all `Celluloid::Error` exceptions are automatically raise inside `Task`s. 
This can potentially cause issues where an Error is incorrectly passed back out of the `Task` as a raised exception, rather than a value. 

There is a potential confusion here between `Celluloid::TimeoutError` and `Celluloid::Task::TimeoutError`. 

_Note_: The timeout PR (#243) reused the same exception class for two different behaviors. 
