### PR TITLE
Synchronize reactor shutdown with message adding

### DIFF
--- a/lib/celluloid/evented_mailbox.rb
+++ b/lib/celluloid/evented_mailbox.rb
@@ -72,8 +72,9 @@ module Celluloid
 
     # Cleanup any IO objects this Mailbox may be using
     def shutdown
-      @reactor.shutdown
-      super
+      super do
+        @reactor.shutdown
+      end
     end
   end
 end

--- a/lib/celluloid/mailbox.rb
+++ b/lib/celluloid/mailbox.rb
@@ -97,6 +97,7 @@ module Celluloid
     def shutdown
       @mutex.lock
       begin
+        yield if block_given?
         messages = @messages
         @messages = []
         @dead = true


### PR DESCRIPTION
Currently there is a small race when terminating an `Actor` using the `EventedMailbox` and any `Actor`s which are linked to it. 

The messages are delivered to the mailbox while the mailbox is shutting down. 

This change ensures that the reactor is shutdown before _OR_ after a message is attempted to be added to the mailbox. 
The result is either the message is delivered, or discarded. 
