### PR TITLE
Use a Condition for Actor#signal/wait

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -243,7 +243,7 @@ module Celluloid
 
     # Send a signal with the given name to all waiting methods
     def signal(name, value = nil)
-      @signals.send name, value
+      @signals.broadcast name, value
     end
 
     # Wait for the given signal

--- a/lib/celluloid/signals.rb
+++ b/lib/celluloid/signals.rb
@@ -1,51 +1,23 @@
 module Celluloid
   # Event signaling between methods of the same object
   class Signals
-    attr_reader :waiting
-
     def initialize
-      @waiting = {}
+      @conditions = {}
     end
 
     # Wait for the given signal and return the associated value
-    def wait(signal)
+    def wait(name)
       raise "cannot wait for signals while exclusive" if Celluloid.exclusive?
 
-      tasks = @waiting[signal]
-      case tasks
-      when Array
-        tasks << Task.current
-      when NilClass
-        @waiting[signal] = Task.current
-      else
-        @waiting[signal] = [tasks, Task.current]
-      end
-
-      Task.suspend :sigwait
+      @conditions[name] ||= Condition.new
+      @conditions[name].wait
     end
 
     # Send a signal to all method calls waiting for the given name
-    # Returns true if any calls were signaled, or false otherwise
-    def send(name, value = nil)
-      tasks = @waiting.delete name
-
-      case tasks
-      when Array
-        tasks.each { |task| run_task task, value }
-        true if tasks.size > 0
-      when NilClass
-        false
-      else
-        run_task tasks, value
-        true
+    def broadcast(name, value = nil)
+      if condition = @conditions.delete(name)
+        condition.broadcast(value)
       end
-    end
-
-    # Run the given task, reporting errors that occur
-    def run_task(task, value)
-      task.resume(value)
-    rescue => ex
-      Logger.crash("signaling error", ex)
     end
   end
 end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -543,18 +543,11 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
           raise "already signaled" if @signaled
 
           @waiting = true
-          signal :future
-
           value = wait :ponycopter
 
           @waiting = false
           @signaled = true
           value
-        end
-
-        def wait_for_future
-          return true if @waiting
-          wait :future
         end
 
         def send_signal(value)
@@ -572,9 +565,11 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
 
       obj.async.wait_for_signal
       obj.should_not be_signaled
+      obj.should be_waiting
 
       obj.send_signal :foobar
       obj.should be_signaled
+      obj.should_not be_waiting
     end
 
     it "sends values along with signals" do
@@ -583,7 +578,6 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
 
       future = obj.future(:wait_for_signal)
 
-      obj.wait_for_future
       obj.should be_waiting
       obj.should_not be_signaled
 


### PR DESCRIPTION
This removes a lot of code. 
The test change was because it was not providing any feature and was trying to `broadcast` to the Condition before the `wait`. 
