### PR TITLE
Add a spec around using custom Thread methods

### DIFF
--- a/spec/celluloid/thread_handle_spec.rb
+++ b/spec/celluloid/thread_handle_spec.rb
@@ -19,4 +19,17 @@ describe Celluloid::ThreadHandle do
   it "supports passing a role" do
     Celluloid::ThreadHandle.new(:useful) { Thread.current.role.should == :useful }.join
   end
+
+  it "supports custom Thread methods" do
+    results = []
+
+    Celluloid::ThreadHandle.new(:method_access) {
+      results << Thread.current.role
+      Fiber.new {
+        results << Thread.current.role
+      }.resume
+    }.join
+
+    results.should == [:method_access, nil]
+  end
 end


### PR DESCRIPTION
Currently JRuby 1.7.4-dev fails this test, it should be necessary for writing sane code. 
We have plans to embrace these methods, having support in JRuby would be good. 

Somewhat related to http://jira.codehaus.org/browse/JRUBY-7081
