### PR TITLE
In-actor termination does not work when the actor is stuck in a infinitely blocking receive

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -387,7 +387,7 @@ module Celluloid
 
   # Terminate this actor
   def terminate
-    Thread.current[:celluloid_actor].terminate
+    Thread.current[:celluloid_actor].proxy.terminate!
   end
 
   # Send a signal with the given name to all waiting methods


### PR DESCRIPTION
From celluloid/celluloid-io#60. 

This issue affects all termination where if the actor has no timers or receivers, it will never terminate. 
