### PR TITLE
Always create a Task regardless of the Actors exclusives

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -487,13 +487,13 @@ module Celluloid
   # Run given block in an exclusive mode: all synchronous calls block the whole
   # actor, not only current message processing.
   def exclusive(&block)
-    Thread.current[:celluloid_actor].exclusive(&block)
+    Thread.current[:celluloid_task].exclusive(&block)
   end
 
   # Are we currently exclusive
   def exclusive?
-    actor = Thread.current[:celluloid_actor]
-    actor && actor.exclusive?
+    task = Thread.current[:celluloid_task]
+    task && task.exclusive?
   end
 
   # Call a block after a given interval, returning a Celluloid::Timer object


### PR DESCRIPTION
This change means that we need a new concept to distinguish the old
behavior which did not create a Task, but instead gave users direct
exclusive access to the actor Thread.

I think people should use one or the other and never use the actor thread. 
