### PR TITLE
rename owner instance variable to hide it

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -21,7 +21,7 @@ module Celluloid
   end
 
   LINKING_TIMEOUT = 5 # linking times out after 5 seconds
-  OWNER_IVAR = :@celluloid_owner # reference to owning actor
+  OWNER_IVAR = :@__celluloid_owner # reference to owning actor
 
   # Actors are Celluloid's concurrency primitive. They're implemented as
   # normal Ruby objects wrapped in threads which communicate with asynchronous


### PR DESCRIPTION
Having to set an instance variable on the target object is bad enough (although I understand why) we should at least try to hide it to offer an easy way for developers to ignore it.
