### PR TITLE
Celluloid::Properties

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -133,12 +133,15 @@ module Celluloid
 
     # Wrap the given subject with an Actor
     def initialize(subject, options = {})
-      @subject      = subject
-      @mailbox      = options[:mailbox] || Mailbox.new
+      @subject = subject
+
+      @mailbox          = options.fetch(:mailbox_class, Mailbox).new
+      @mailbox.max_size = options.fetch(:mailbox_size, nil)
+
+      @task_class   = options[:task_class] || Celluloid.task_class
       @exit_handler = options[:exit_handler]
       @exclusives   = options[:exclusive_methods]
       @receiver_block_executions = options[:receiver_block_executions]
-      @task_class   = options[:task_class] || Celluloid.task_class
 
       @tasks     = TaskSet.new
       @links     = Links.new

--- a/lib/celluloid/properties.rb
+++ b/lib/celluloid/properties.rb
@@ -1,13 +1,15 @@
 module Celluloid
   # Properties define inheritable attributes of classes, somewhat similar to
-  # Rails cattr_*/mattr_*
-  module Property
+  # Rails cattr_*/mattr_* or class_attribute
+  module Properties
     def property(name, opts = {})
       default   = opts.fetch(:default, nil)
+      multi     = opts.fetch(:multi, false)
       ivar_name = "@#{name}".to_sym
 
-      ancestors.first.send(:define_singleton_method, name) do |value = nil|
+      ancestors.first.send(:define_singleton_method, name) do |value = nil, *extra|
         if value
+          value = value ? [value, *extra] : [] if multi
           instance_variable_set(ivar_name, value)
         elsif instance_variables.include?(ivar_name)
           instance_variable_get(ivar_name)

--- a/spec/celluloid/properties_spec.rb
+++ b/spec/celluloid/properties_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe Celluloid::Property do
+describe Celluloid::Properties do
   let(:default_value) { 42 }
   let(:changed_value) { 43 }
 
   let(:example_class) do
     Class.new do
-      extend Celluloid::Property
+      extend Celluloid::Properties
       property :baz, :default => 42
     end
   end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -901,12 +901,12 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     end
   end
 
-  context :mailbox_limit do
+  context :mailbox_size do
     subject do
       Class.new do
         include included_module
         task_class task_klass
-        mailbox.max_size = 100
+        mailbox_size 100
       end
     end
 


### PR DESCRIPTION
A "property" macro for adding declarative properties to a class which are
inherited but overridable in subclasses. Sort of like what class variables
always should've been.

Just an idea for now, but this can be used to replace things like
"mailbox_class" and "execute_block_on_receiver"
