### PR TITLE
Allow supervision group run/run! inits to use a private actor registry

### DIFF
--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -11,8 +11,8 @@ module Celluloid
       end
 
       # Start this application (and watch it with a supervisor)
-      def run!(reg=nil)
-        group = new(reg) do |_group|
+      def run!(registry = nil)
+        group = new(registry) do |_group|
           blocks.each do |block|
             block.call(_group)
           end
@@ -21,9 +21,9 @@ module Celluloid
       end
 
       # Run the application in the foreground with a simple watchdog
-      def run(reg=nil)
+      def run(registry = nil)
         loop do
-          supervisor = run!(reg)
+          supervisor = run!(registry)
 
           # Take five, toplevel supervisor
           sleep 5 while supervisor.alive?

--- a/spec/celluloid/supervision_group_spec.rb
+++ b/spec/celluloid/supervision_group_spec.rb
@@ -21,13 +21,11 @@ describe Celluloid::SupervisionGroup do
   end
 
   it "accepts a private actor registry" do
-    my_reg = Celluloid::Registry.new
-
-    MyGroup.run!(my_reg)
+    my_registry = Celluloid::Registry.new
+    MyGroup.run!(my_registry)
     sleep 0.01
 
-    my_reg[:example].should be_running
-
+    my_registry[:example].should be_running
   end
 
   context "pool" do


### PR DESCRIPTION
The SupervisionGroup initializer allows a private actor registry to be supplied/used, but neither the class level run/run! methods currently allow this functionality to be used.  Patch corrects this by adding an optional registry parameter to each method's signature.  Should not break existing code, as parameter defaults to nil.
