### PR TITLE
Add backtraces to "Dangerously suspending task" messages

### DIFF
--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -71,7 +71,14 @@ module Celluloid
       @status = status
 
       if @dangerous_suspend
-        Logger.warn "Dangerously suspending task: type=#{@type.inspect}, meta=#{@meta.inspect}, status=#{@status.inspect}"
+        warning = "Dangerously suspending task: "
+        warning << [
+          "type=#{@type.inspect}",
+          "meta=#{@meta.inspect}",
+          "status=#{@status.inspect}"
+        ].join(", ")
+
+        Logger.warn [warning, *caller[2..8]].join("\n\t")
       end
 
       value = signal

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -144,7 +144,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     end
 
     Celluloid.logger = mock.as_null_object
-    Celluloid.logger.should_receive(:warn).with("Dangerously suspending task: type=:call, meta={:method_name=>:initialize}, status=:sleeping")
+    Celluloid.logger.should_receive(:warn).with(/Dangerously suspending task: type=:call, meta={:method_name=>:initialize}, status=:sleeping/)
 
     actor = klass.new
     actor.terminate
@@ -171,7 +171,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     end
 
     Celluloid.logger = mock.as_null_object
-    Celluloid.logger.should_receive(:warn).with("Dangerously suspending task: type=:finalizer, meta={:method_name=>:cleanup}, status=:sleeping")
+    Celluloid.logger.should_receive(:warn).with(/Dangerously suspending task: type=:finalizer, meta={:method_name=>:cleanup}, status=:sleeping/)
 
     actor = klass.new
     actor.terminate


### PR DESCRIPTION
Right now there's no way to determine where dangerous suspends are occurring.
Including backtraces in the warning message alows us to track down where these
problems are coming from.

Downside: it makes the warning messages longer
Upside: we can find and eliminate them!
