### PR TITLE
Pluralize actor(s)

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -137,7 +137,7 @@ module Celluloid
       Timeout.timeout(shutdown_timeout) do
         internal_pool.shutdown
 
-        Logger.debug "Terminating #{actors.size} actors..." if actors.size > 0
+        Logger.debug "Terminating #{actors.size} #{(actors.size > 1) ? 'actors' : 'actor'}..." if actors.size > 0
 
         # Attempt to shut down the supervision tree, if available
         Supervisor.root.terminate if Supervisor.root


### PR DESCRIPTION
Whilst adding some pluralization for ( the nearly finished ) [multi_sync](https://github.com/karlfreeman/multi_sync) It started grating on me that I was terminating `1 Actors`.

Keep up the good work! :+1: 
