### PR TITLE
Celluloid::Method should respond to Method methods

### DIFF
--- a/lib/celluloid/method.rb
+++ b/lib/celluloid/method.rb
@@ -13,6 +13,14 @@ module Celluloid
       @proxy.method_missing(:method, @name).arity
     end
 
+    def name
+      @proxy.method_missing(:method, @name).name
+    end
+
+    def parameters
+      @proxy.method_missing(:method, @name).parameters
+    end
+
     def call(*args, &block)
       @proxy.__send__(@name, *args, &block)
     end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -65,6 +65,19 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     method.arity.should be(1)
   end
 
+  it "supports #name calls via #method" do
+    method = actor_class.new("Troy McClure").method(:greet)
+    method.name.should == :greet
+  end
+
+  it "supports #parameters via #method" do
+    method = actor_class.new("Troy McClure").method(:greet)
+    method.parameters.should == []
+
+    method = actor_class.new("Troy McClure").method(:change_name)
+    method.parameters.should == [[:req, :new_name]]
+  end
+
   it "supports future(:method) syntax for synchronous future calls" do
     actor = actor_class.new "Troy McClure"
     future = actor.future :greet


### PR DESCRIPTION
When you use Celluloid Actor you will use proxy class Celluloid::Method
to execute code through actor in sync or async way. Some libraries expects
that Method (Celluloid::Method) object will be respond to methods from
standard library Method.

This bug is related to: https://github.com/psyho/bogus/issues/24
