### PR TITLE
InternalPool does not support non-Celluloid threads being created

### DIFF
--- a/lib/celluloid/internal_pool.rb
+++ b/lib/celluloid/internal_pool.rb
@@ -84,6 +84,7 @@ module Celluloid
         thread.busy = false
         if idle_size >= @max_idle
           thread[:celluloid_queue] << nil
+          @threads.delete(thread)
         else
           clean_thread_locals(thread)
         end

--- a/spec/celluloid/internal_pool_spec.rb
+++ b/spec/celluloid/internal_pool_spec.rb
@@ -40,4 +40,13 @@ describe Celluloid::InternalPool do
     subject.idle_size.should eq 1
     subject.busy_size.should eq 0
   end
+
+  it "doesn't leak dead threads" do
+    subject.max_idle = 0 # Instruct the pool to immediately shut down the thread.
+    subject.get { true }.should be_a(Celluloid::Thread)
+
+    sleep 0.01 # hax
+
+    subject.to_a.should have(0).items
+  end
 end


### PR DESCRIPTION
If a new `Thread` is created within a `Celluloid::Thread`, that thread is in the pool's `ThreadGroup`. 

This means that we are now tracking a `Thread` which is not created by us. 

@aflatter discovered [this](https://gist.github.com/aflatter/ff20c9763b768b623956). 
