### PR TITLE
Raise on JRuby 1.7.3 warning Celluloid is broken

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -5,6 +5,10 @@ require 'set'
 
 require 'celluloid/version'
 
+if defined?(JRUBY_VERSION) && JRUBY_VERSION == "1.7.3"
+  raise "Celluloid is broken on JRuby 1.7.3. Please upgrade to 1.7.4+"
+end
+
 module Celluloid
   Error = Class.new StandardError
 


### PR DESCRIPTION
After helping someone debug this _again_ today I think our best bet is
to simply have Celluloid raise if someone tries to require it on JRuby
1.7.3:

```
$ bundle exec irb -rcelluloid
RuntimeError: Celluloid is broken on JRuby 1.7.3. Please upgrade to
1.7.4+
```
