### PR TITLE
Add a timer for timeout without allocating a new Task

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -416,16 +416,9 @@ module Celluloid
 
   # Timeout on task suspension (eg Sync calls to other actors)
   def timeout(duration)
-    bt = caller
-    task = Task.current
-    timer = after(duration) do
-      exception = Task::TimeoutError.new
-      exception.set_backtrace bt
-      task.resume exception
+    Thread.current[:celluloid_actor].timeout(duration) do
+      yield
     end
-    yield
-  ensure
-    timer.cancel if timer
   end
 
   # Run given block in an exclusive mode: all synchronous calls block the whole

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -268,6 +268,19 @@ module Celluloid
       @timers.every(interval) { task(:timer, &block) }
     end
 
+    def timeout(duration)
+      bt = caller
+      task = Task.current
+      timer = @timers.after(duration) do
+        exception = Task::TimeoutError.new("execution expired")
+        exception.set_backtrace bt
+        task.resume exception
+      end
+      yield
+    ensure
+      timer.cancel if timer
+    end
+
     class Sleeper
       def initialize(timers, interval)
         @timers = timers


### PR DESCRIPTION
We should not allocated a new `Task` when we are simply scheduling the termination of the current `Task`. 
