### PR TITLE
Use a Celluloid::Version class instead of a constant.

### DIFF
--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -1,10 +1,7 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
-require 'celluloid/version'
-
 Gem::Specification.new do |gem|
   gem.name        = 'celluloid'
-  gem.version     = Celluloid::VERSION
+  gem.version     = '0.15.0.pre'
   gem.platform    = Gem::Platform::RUBY
   gem.summary     = 'Actor-based concurrent object framework for Ruby'
   gem.description = 'Celluloid enables people to build concurrent programs out of concurrent objects just as easily as they build sequential programs out of sequential objects'

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -3,13 +3,12 @@ require 'thread'
 require 'timeout'
 require 'set'
 
-require 'celluloid/version'
-
 if defined?(JRUBY_VERSION) && JRUBY_VERSION == "1.7.3"
   raise "Celluloid is broken on JRuby 1.7.3. Please upgrade to 1.7.4+"
 end
 
 module Celluloid
+  VERSION = '0.15.0.pre'
   Error = Class.new StandardError
 
   extend self # expose all instance methods as singleton methods
@@ -171,6 +170,10 @@ module Celluloid
       end
     ensure
       internal_pool.kill
+    end
+
+    def version
+      VERSION
     end
   end
 

--- a/lib/celluloid/version.rb
+++ b/lib/celluloid/version.rb
@@ -1,4 +1,0 @@
-module Celluloid
-  VERSION = '0.15.0.pre'
-  def self.version; VERSION; end
-end


### PR DESCRIPTION
This is a WIP to fix [the trello issue Tim sent me](https://trello.com/c/Pmjk5yz7)

Is there a spec for this that I can use? I'm guessing due to its nature it may be hard to test.

Is this even remotely going to scratch the surface of fixing this issue?

I'm not convinced this does anything, but I'm interested in opening up a dialogue around this issue to understand the root cause of how you include Celluloid without requiring it.
