### PR TITLE
Refactor Pools using message API

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -216,12 +216,12 @@ module Celluloid
     # * args: array of arguments to pass when creating a worker
     #
     def pool(options = {})
-      PoolManager.new(self, options)
+      PoolManager.new(self, options).pool
     end
 
     # Same as pool, but links to the pool manager
     def pool_link(options = {})
-      PoolManager.new_link(self, options)
+      PoolManager.new_link(self, options).pool
     end
 
     # Run an actor in the foreground
@@ -483,6 +483,7 @@ require 'celluloid/links'
 require 'celluloid/logger'
 require 'celluloid/mailbox'
 require 'celluloid/evented_mailbox'
+require 'celluloid/forwarding_mailbox'
 require 'celluloid/method'
 require 'celluloid/properties'
 require 'celluloid/receivers'
@@ -502,6 +503,7 @@ require 'celluloid/proxies/actor_proxy'
 require 'celluloid/proxies/async_proxy'
 require 'celluloid/proxies/future_proxy'
 require 'celluloid/proxies/block_proxy'
+require 'celluloid/proxies/pool_proxy'
 
 require 'celluloid/actor'
 require 'celluloid/future'

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -148,4 +148,21 @@ module Celluloid
     end
   end
 
+  # ForwardingCall allows a mailbox to forward its messages to another.
+  class ForwardingCall < Call
+
+    # Do not block if no work found
+    TIMEOUT = 0
+
+    def initialize(sender)
+      @sender = sender
+    end
+
+    # Pull the next message from the sender, if available
+    def dispatch(obj)
+      msg = @sender.receive(TIMEOUT)
+      ::Celluloid.mailbox << msg if msg
+    end
+  end
+
 end

--- a/lib/celluloid/forwarding_mailbox.rb
+++ b/lib/celluloid/forwarding_mailbox.rb
@@ -1,0 +1,58 @@
+# A variant of Celluloid::Mailbox which forwards messages to subscribers
+module Celluloid
+  class ForwardingMailbox < Mailbox
+    # Add a message to the Mailbox
+    #
+    # Slight modification of Celluloid::Mailbox to *not* fast-track SystemEvents
+    def <<(message)
+      @mutex.lock
+      begin
+        if mailbox_full
+          Logger.debug "Discarded message: #{message}"
+          return
+        end
+        raise MailboxError, "dead recipient" if @dead
+        @messages << message
+
+        signal
+        nil
+      ensure
+        @mutex.unlock rescue nil
+      end
+    end
+
+    # List all subscribers
+    def subscribers
+      @subscribers ||= Set.new
+    end
+
+    # Subscribe to this mailbox for updates of new messages
+    # @param subscriber [Object] the subscriber to send messages to
+    def add_subscriber(subscriber)
+      subscribers << subscriber
+    end
+
+    # Remove a subscriber from thie mailbox
+    # @param subscriber [Object] the subscribed object
+    def remove_subscriber(subscriber)
+      subscribers.delete subscriber
+    end
+
+    private
+    # Signal new work to all subscribers/waiters
+    def signal
+      @condition.signal
+
+      subscribers.each do |sub|
+        sig = Celluloid::ForwardingCall.new self
+        begin
+          sub << sig
+        rescue Celluloid::MailboxError
+          # Mailbox died, remove subscriber
+          subscribers.delete(sub)
+        end
+      end
+      nil
+    end
+  end
+end

--- a/lib/celluloid/proxies/pool_proxy.rb
+++ b/lib/celluloid/proxies/pool_proxy.rb
@@ -1,0 +1,29 @@
+# A proxy object which sends calls to a Pool's shared mailbox
+module Celluloid
+  class PoolProxy < ActorProxy
+     def initialize(manager)
+      @mailbox       = manager.master_mailbox
+      @klass         = manager.worker_class.to_s
+      @sync_proxy    = SyncProxy.new(@mailbox, @klass)
+      @async_proxy   = AsyncProxy.new(@mailbox, @klass)
+      @future_proxy  = FutureProxy.new(@mailbox, @klass)
+
+      @manager_proxy = manager
+    end
+
+    # Escape route to access the QueueManager actor from the QueueProxy
+    def __manager__
+      @manager_proxy
+    end
+
+    # Reroute terminate to the queue manager
+    def terminate
+      __manager__.terminate
+    end
+
+    def inspect
+      orig = super
+      orig.sub("ActorProxy", "PoolProxy")
+    end
+  end
+end

--- a/spec/celluloid/forwarding_mailbox_spec.rb
+++ b/spec/celluloid/forwarding_mailbox_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Celluloid::ForwardingMailbox do
+  let(:mailbox) { Celluloid::Mailbox.new }
+  let(:origin) { Celluloid::ForwardingMailbox.new }
+
+  describe '#add_subscriber' do
+    it 'adds a subscriber to the list of subscribers' do
+      origin.add_subscriber(mailbox)
+      origin.subscribers.should include(mailbox)
+    end
+  end
+
+  describe '#<<' do
+    it 'publishes a ForwardingCall to all subscribers' do
+      origin.add_subscriber(mailbox)
+      mailbox.should_receive(:<<).with(kind_of(Celluloid::ForwardingCall))
+      origin << "New work"
+    end
+  end
+end

--- a/spec/celluloid/pool_spec.rb
+++ b/spec/celluloid/pool_spec.rb
@@ -14,22 +14,17 @@ describe "Celluloid.pool" do
       end
     end
 
+    def sleepy(time = 0.1)
+      sleep time
+      :done
+    end
+
     def crash
       raise ExampleError, "zomgcrash"
     end
   end
 
   subject { MyWorker.pool }
-
-  it "processes work units synchronously" do
-    subject.process.should be :done
-  end
-
-  it "processes work units asynchronously" do
-    queue = Queue.new
-    subject.async.process(queue)
-    queue.pop.should be :done
-  end
 
   it "handles crashes" do
     expect { subject.crash }.to raise_error(ExampleError)
@@ -46,7 +41,55 @@ describe "Celluloid.pool" do
     new_actors.should eq []
   end
 
-  it "terminates" do
-    expect { subject.terminate }.to_not raise_exception
+  describe '#terminate' do
+    it 'terminates the manager' do
+      subject.terminate
+      subject.should_not be_alive
+    end
+
+    it 'terminates the pool' do
+      expect{ subject.terminate }.to change { Celluloid::Actor.all.size }.by(0)
+    end
+  end
+
+  describe '#sync' do
+    it 'processs calls synchronously' do
+      subject.process.should be :done
+    end
+  end
+
+  describe '#async' do
+    it 'processs calls asynchronously' do
+      q = Queue.new
+      subject.async.process(q)
+      q.pop.should be :done
+    end
+
+    it 'processes additional work when workers are sleeping' do
+      start_time = Time.now
+      vals = 10.times.map { subject.future.sleepy }
+      vals.each { |v| v.value }
+      (start_time - Time.now).should be < 0.3
+    end
+  end
+
+  describe '#future' do
+    it 'processes calls as futures' do
+      f = subject.future.process
+      f.value.should be :done
+    end
+  end
+
+  describe '#size=' do
+    let(:manager) { subject.__manager__ }
+    it 'increases the size of the pool' do
+      manager.size.should eq Celluloid.cores
+      expect { manager.size += 1 }.to change{ Celluloid::Actor.all.size }.by(1)
+    end
+
+    it 'reduces the size of the pool' do
+      manager.size.should eq Celluloid.cores
+      expect { manager.size -= 1 }.to change{ Celluloid::Actor.all.size }.by(-1)
+    end
   end
 end


### PR DESCRIPTION
While working on my own background queuing solution, [WindUp](https://github.com/ryanlchan/wind_up), I ended up reimplementing Celluloid.pool using the message API. The result is a drop-in replacement for pools, with a few changes:
- Asynchronous message passing - using Celluloid's Messaging API means
  any blocking call (i.e. #sleep, Celluloid::IO, etc) allows the actor to
  process another message
- Separate proxies for PoolManager and pools - no more unexpected behavior
  between #is_a? and #class and #responds_to?

Separating the proxies _may_ cause some incompatibilities, but I haven't yet found any.

Let me know if this should wait for issue #291 (behavior separation) to complete.
