### PR TITLE
Fix supervision groups not cleaning registry on terminate

### DIFF
--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -148,6 +148,7 @@ module Celluloid
       end
 
       def terminate
+        @registry.delete(@name) if @name
         @actor.terminate if @actor
       rescue DeadActorError
       end

--- a/spec/celluloid/supervision_group_spec.rb
+++ b/spec/celluloid/supervision_group_spec.rb
@@ -28,6 +28,12 @@ describe Celluloid::SupervisionGroup do
     my_registry[:example].should be_running
   end
 
+  it "removes actors from the registry when terminating" do
+    group = MyGroup.run!
+    group.terminate
+    Celluloid::Actor[:example].should be_nil
+  end
+
   context "pool" do
     before :all do
       class MyActor


### PR DESCRIPTION
I believe the following scenario is what is intended:
- SupervisionGroups link to their members.
- When a member exits, #restart_actor is called with the reason.
- If #restart_actor is given no reason, it will assume a clean shutdown and do nothing.

Unfortunately, I believe that when we terminate a SupervisionGroup, it will terminate all its members in its’ finalizer, and then immediately exit before it is able to receive #restart_actor(actor, empty_reason), and thus the registry won’t be cleared.

I believe my pull request is probably the easiest solution, but not one of the better ones because it feals brittle.

Perhaps the registry would do good to link to its members in a similar fashion to how the SupervisionGroup does? After all, the Registry is kind of similar to a SupervisionGroup; except it does not ensure actors are alive, but allows retrieval of actors by name. That’s a bigger change and not in scope for this pull request, however. Just a thought. :)
