### PR TITLE
PoolManager resumes a task from inside a task

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -91,6 +91,7 @@ module Celluloid
 
     # Provision a new worker
     def __provision_worker__
+      Task.current.guard_warnings = true
       while @idle.empty?
         # Wait for responses from one of the busy workers
         response = exclusive { receive { |msg| msg.is_a?(Response) } }

--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -25,7 +25,7 @@ module Celluloid
     end
 
     attr_reader :type, :meta, :status
-    attr_accessor :chain_id
+    attr_accessor :chain_id, :guard_warnings
 
     # Create a new task
     def initialize(type, meta)
@@ -35,6 +35,7 @@ module Celluloid
 
       @exclusive         = false
       @dangerous_suspend = @meta ? @meta.delete(:dangerous_suspend) : false
+      @guard_warnings    = false
 
       actor     = Thread.current[:celluloid_actor]
       @chain_id = CallChain.current_id
@@ -93,7 +94,7 @@ module Celluloid
 
     # Resume a suspended task, giving it a value to return if needed
     def resume(value = nil)
-      raise "Cannot resume a task from inside of a task" if Thread.current[:celluloid_task]
+      guard "Cannot resume a task from inside of a task" if Thread.current[:celluloid_task]
       deliver(value)
       nil
     end
@@ -140,6 +141,14 @@ module Celluloid
     # Nicer string inspect for tasks
     def inspect
       "#<#{self.class}:0x#{object_id.to_s(16)} @type=#{@type.inspect}, @meta=#{@meta.inspect}, @status=#{@status.inspect}>"
+    end
+
+    def guard(message)
+      if @guard_warnings
+        Logger.warn message if $CELLULOID_DEBUG
+      else
+        raise message
+      end
     end
   end
 end

--- a/spec/celluloid/pool_spec.rb
+++ b/spec/celluloid/pool_spec.rb
@@ -49,4 +49,11 @@ describe "Celluloid.pool" do
   it "terminates" do
     expect { subject.terminate }.to_not raise_exception
   end
+
+  it "handles many requests" do
+    futures = 10.times.map do
+      subject.future.process
+    end
+    futures.map(&:value)
+  end
 end


### PR DESCRIPTION
As of 0.15.0 I am seeing this error "Cannot resume a task from inside of a task" when using a pool.  I was able to repro with this little snippet.  Running JRuby 1.7.2.

``` ruby
class Worker
  include Celluloid
  def perform(callable, *args)
    callable.call(*args)
  end
end

callable = lambda { |number| number + 1 }

pool = Worker.pool(:size => 2)
10.times { pool.async.perform(callable, 1) }
```

```
jruby-1.7.2 :057 > Celluloid::PoolManager crashed!
RuntimeError: Cannot resume a task from inside of a task
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/tasks.rb:96:in `resume'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/responses.rb:11:in `dispatch'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/actor.rb:327:in `handle_message'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/pool_manager.rb:97:in `__provision_worker__'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/pool_manager.rb:38:in `_send_'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/pool_manager.rb:122:in `method_missing'
org/jruby/RubyKernel.java:1806:in `public_send'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/calls.rb:25:in `dispatch'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/calls.rb:122:in `dispatch'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/actor.rb:322:in `handle_message'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/actor.rb:416:in `task'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/tasks.rb:54:in `initialize'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/tasks.rb:46:in `initialize'
/vendor/jruby/1.9/gems/celluloid-0.15.0/lib/celluloid/tasks/task_fiber.rb:13:in `create'




```
