### PR TITLE
Linking actors can cause tasks to be created incorrectly

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -222,7 +222,7 @@ module Celluloid
           when LinkingResponse
             Celluloid::Probe.actors_linked(self, receiver) if $CELLULOID_MONITORING
             # We're done!
-            system_events.each { |ev| handle_system_event(ev) }
+            system_events.each { |ev| @mailbox << ev }
             return
           when NilClass
             raise TimeoutError, "linking timeout of #{LINKING_TIMEOUT} seconds exceeded"


### PR DESCRIPTION
When we are linking, we defer the handling of `SystemEvents`. 
The problem is that if we receive an `ExitEvent` while we are linking, we will handle it while we are still running the parent method call. 

I propose that we keep the SystemEvents until the event loop is given back control. 
This is what would happen if that `ExitEvent` is delayed until the linking is complete. 

We could reinsert the `SystemEvent` messages back into the mailbox. 

/cc mperham/sidekiq#1161
