### PR TITLE
Create ActorSystem for saner encapsulation of all global structures

### DIFF
--- a/lib/celluloid/actor_system.rb
+++ b/lib/celluloid/actor_system.rb
@@ -1,0 +1,107 @@
+module Celluloid
+  class ActorSystem
+    extend Forwardable
+
+    def initialize
+      @internal_pool = InternalPool.new
+      @registry      = Registry.new
+    end
+    attr_reader :registry
+
+    # Launch default services
+    # FIXME: We should set up the supervision hierarchy here
+    def start
+      within do
+        Celluloid::Notifications::Fanout.supervise_as :notifications_fanout
+        Celluloid::IncidentReporter.supervise_as :default_incident_reporter, STDERR
+      end
+      true
+    end
+
+    def within
+      old = Thread.current[:celluloid_actor_system]
+      Thread.current[:celluloid_actor_system] = self
+      yield
+    ensure
+      Thread.current[:celluloid_actor_system] = old
+    end
+
+    def get_thread
+      @internal_pool.get do
+        Thread.current[:celluloid_actor_system] = self
+        yield
+      end
+    end
+
+    def stack_dump
+      Celluloid::StackDump.new(@internal_pool)
+    end
+
+    def_delegators "@registry", :[], :get, :[]=, :set, :delete
+
+    def registered
+      @registry.names
+    end
+
+    def clear_registry
+      @registry.clear
+    end
+
+    def running
+      actors = []
+      @internal_pool.each do |t|
+        next unless t.role == :actor
+        actors << t.actor.behavior_proxy if t.actor && t.actor.respond_to?(:behavior_proxy)
+      end
+      actors
+    end
+
+    def running?
+      @internal_pool.running?
+    end
+
+    # Shut down all running actors
+    def shutdown
+      actors = running
+      Timeout.timeout(shutdown_timeout) do
+        @internal_pool.shutdown
+
+        Logger.debug "Terminating #{actors.size} #{(actors.size > 1) ? 'actors' : 'actor'}..." if actors.size > 0
+
+        # Actors cannot self-terminate, you must do it for them
+        actors.each do |actor|
+          begin
+            actor.terminate!
+          rescue DeadActorError
+          end
+        end
+
+        actors.each do |actor|
+          begin
+            Actor.join(actor)
+          rescue DeadActorError
+          end
+        end
+      end
+    rescue Timeout::Error
+      Logger.error("Couldn't cleanly terminate all actors in #{shutdown_timeout} seconds!")
+      actors.each do |actor|
+        begin
+          Actor.kill(actor)
+        rescue DeadActorError, MailboxDead
+        end
+      end
+    ensure
+      @internal_pool.kill
+      clear_registry
+    end
+
+    def assert_inactive
+      @internal_pool.assert_inactive
+    end
+
+    def shutdown_timeout
+      Celluloid.shutdown_timeout
+    end
+  end
+end

--- a/lib/celluloid/future.rb
+++ b/lib/celluloid/future.rb
@@ -8,7 +8,7 @@ module Celluloid
       return super unless block
 
       future = new
-      Celluloid::ThreadHandle.new(:future) do
+      Celluloid::ThreadHandle.new(Celluloid.actor_system, :future) do
         begin
           call = SyncCall.new(future, :call, args)
           call.dispatch(block)

--- a/lib/celluloid/registry.rb
+++ b/lib/celluloid/registry.rb
@@ -3,10 +3,6 @@ require 'thread'
 module Celluloid
   # The Registry allows us to refer to specific actors by human-meaningful names
   class Registry
-    class << self
-      attr_reader :root
-    end
-
     def initialize
       @registry = {}
       @registry_lock = Mutex.new
@@ -57,8 +53,5 @@ module Celluloid
       end
       hash
     end
-
-    # Create the default registry
-    @root = new
   end
 end

--- a/lib/celluloid/stack_dump.rb
+++ b/lib/celluloid/stack_dump.rb
@@ -69,7 +69,9 @@ module Celluloid
 
     attr_accessor :actors, :threads
 
-    def initialize
+    def initialize(internal_pool)
+      @internal_pool = internal_pool
+
       @actors  = []
       @threads = []
 
@@ -77,7 +79,7 @@ module Celluloid
     end
 
     def snapshot
-      Celluloid.internal_pool.each do |thread|
+      @internal_pool.each do |thread|
         if thread.role == :actor
           @actors << snapshot_actor(thread.actor) if thread.actor
         else
@@ -118,7 +120,7 @@ module Celluloid
       ThreadState.new(thread.object_id, thread.backtrace, thread.role)
     end
 
-    def dump(output = STDERR)
+    def print(output = STDERR)
       @actors.each do |actor|
         output.print actor.dump
       end

--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -58,7 +58,7 @@ module Celluloid
     # Start the group
     def initialize(registry = nil)
       @members = []
-      @registry = registry || Registry.root
+      @registry = registry || Celluloid.actor_system.registry
 
       yield current_actor if block_given?
     end

--- a/lib/celluloid/tasks/task_fiber.rb
+++ b/lib/celluloid/tasks/task_fiber.rb
@@ -6,10 +6,12 @@ module Celluloid
 
     def create
       queue = Thread.current[:celluloid_queue]
+      actor_system = Thread.current[:celluloid_actor_system]
       @fiber = Fiber.new do
         # FIXME: cannot use the writer as specs run inside normal Threads
         Thread.current[:celluloid_role] = :actor
         Thread.current[:celluloid_queue] = queue
+        Thread.current[:celluloid_actor_system] = actor_system
         yield
       end
     end

--- a/lib/celluloid/tasks/task_thread.rb
+++ b/lib/celluloid/tasks/task_thread.rb
@@ -12,7 +12,8 @@ module Celluloid
     end
 
     def create
-      @thread = Celluloid::ThreadHandle.new(:task) do
+      # TODO: move this to ActorSystem#get_thread (ThreadHandle inside InternalPool)
+      @thread = ThreadHandle.new(Thread.current[:celluloid_actor_system], :task) do
         begin
           ex = @resume_queue.pop
           raise ex if ex.is_a?(Task::TerminatedError)

--- a/lib/celluloid/thread_handle.rb
+++ b/lib/celluloid/thread_handle.rb
@@ -3,11 +3,11 @@ module Celluloid
   # accidentally do things to threads which have been returned to the pool,
   # such as, say, killing them
   class ThreadHandle
-    def initialize(role = nil)
+    def initialize(actor_system, role = nil)
       @mutex = Mutex.new
       @join  = ConditionVariable.new
 
-      @thread = Celluloid.internal_pool.get do
+      @thread = actor_system.get_thread do
         Thread.current.role = role
         begin
           yield

--- a/spec/celluloid/actor_spec.rb
+++ b/spec/celluloid/actor_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Celluloid do
+describe Celluloid, actor_system: :global do
   it_behaves_like "a Celluloid Actor", Celluloid
 end

--- a/spec/celluloid/block_spec.rb
+++ b/spec/celluloid/block_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Blocks" do
+describe "Blocks", actor_system: :global do
   class MyBlockActor
     include Celluloid
 

--- a/spec/celluloid/calls_spec.rb
+++ b/spec/celluloid/calls_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::SyncCall do
+describe Celluloid::SyncCall, actor_system: :global do
   class CallExampleActor
     include Celluloid
 

--- a/spec/celluloid/condition_spec.rb
+++ b/spec/celluloid/condition_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::Condition do
+describe Celluloid::Condition, actor_system: :global do
   class ConditionExample
     include Celluloid
 

--- a/spec/celluloid/fsm_spec.rb
+++ b/spec/celluloid/fsm_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::FSM do
+describe Celluloid::FSM, actor_system: :global do
   before :all do
     class TestMachine
       include Celluloid::FSM

--- a/spec/celluloid/future_spec.rb
+++ b/spec/celluloid/future_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::Future do
+describe Celluloid::Future, actor_system: :global do
   it "creates future objects that can be retrieved later" do
     future = Celluloid::Future.new { 40 + 2 }
     future.value.should == 42

--- a/spec/celluloid/notifications_spec.rb
+++ b/spec/celluloid/notifications_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::Notifications do
+describe Celluloid::Notifications, actor_system: :global do
   class Admirer
     include Celluloid
     include Celluloid::Notifications

--- a/spec/celluloid/pool_spec.rb
+++ b/spec/celluloid/pool_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Celluloid.pool" do
+describe "Celluloid.pool", actor_system: :global do
   class ExampleError < StandardError; end
 
   class MyWorker

--- a/spec/celluloid/probe_spec.rb
+++ b/spec/celluloid/probe_spec.rb
@@ -36,7 +36,7 @@ class TestProbeClient
   end
 end
 
-describe "Probe" do
+describe "Probe", actor_system: :global do
   describe 'on boot' do
     it 'should capture system actor spawn' do
       client = TestProbeClient.new

--- a/spec/celluloid/registry_spec.rb
+++ b/spec/celluloid/registry_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::Registry do
+describe Celluloid::Registry, actor_system: :global do
   class Marilyn
     include Celluloid
 
@@ -36,12 +36,12 @@ describe Celluloid::Registry do
     end
 
     it "removes reference to actors' name from the registry" do
-      Celluloid::Registry.root.delete(:marilyn)
+      Celluloid::Actor.delete(:marilyn)
       Celluloid::Actor.registered.should_not include :marilyn
     end
 
     it "returns actor removed from the registry" do
-      rval = Celluloid::Registry.root.delete(:marilyn)
+      rval = Celluloid::Actor.delete(:marilyn)
       rval.should be_kind_of(Marilyn)
     end
   end

--- a/spec/celluloid/supervision_group_spec.rb
+++ b/spec/celluloid/supervision_group_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::SupervisionGroup do
+describe Celluloid::SupervisionGroup, actor_system: :global do
   before :all do
     class MyActor
       include Celluloid

--- a/spec/celluloid/supervisor_spec.rb
+++ b/spec/celluloid/supervisor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Celluloid::Supervisor do
+describe Celluloid::Supervisor, actor_system: :global do
   class SubordinateDead < StandardError; end
 
   class Subordinate

--- a/spec/celluloid/tasks/task_thread_spec.rb
+++ b/spec/celluloid/tasks/task_thread_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
 describe Celluloid::TaskThread do
+  around(:each) do |example|
+    Celluloid::ActorSystem.new.within { example.run }
+  end
+
   it_behaves_like "a Celluloid Task", Celluloid::TaskThread
 end

--- a/spec/celluloid/thread_handle_spec.rb
+++ b/spec/celluloid/thread_handle_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 describe Celluloid::ThreadHandle do
+  let(:actor_system) do
+    Celluloid::ActorSystem.new
+  end
+
   it "knows thread liveliness" do
     queue = Queue.new
-    handle = Celluloid::ThreadHandle.new { queue.pop }
+    handle = Celluloid::ThreadHandle.new(actor_system) { queue.pop }
     handle.should be_alive
 
     queue << :die
@@ -13,10 +17,10 @@ describe Celluloid::ThreadHandle do
   end
 
   it "joins to thread handles" do
-    Celluloid::ThreadHandle.new { sleep 0.01 }.join
+    Celluloid::ThreadHandle.new(actor_system) { sleep 0.01 }.join
   end
 
   it "supports passing a role" do
-    Celluloid::ThreadHandle.new(:useful) { Thread.current.role.should == :useful }.join
+    Celluloid::ThreadHandle.new(actor_system, :useful) { Thread.current.role.should == :useful }.join
   end
 end

--- a/spec/support/task_examples.rb
+++ b/spec/support/task_examples.rb
@@ -17,11 +17,13 @@ shared_context "a Celluloid Task" do |task_class|
   subject { task_class.new(task_type, {}) { Celluloid::Task.suspend(suspend_state) } }
 
   before :each do
+    Thread.current[:celluloid_actor_system] = Celluloid.actor_system
     Thread.current[:celluloid_actor] = actor
   end
 
   after :each do
     Thread.current[:celluloid_actor] = nil
+    Thread.current[:celluloid_actor_system] = nil
   end
 
   it "begins with status :new" do


### PR DESCRIPTION
This currently contains all of the global structures in one place. 
See the [Trello](https://trello.com/c/XfCcOGyk) for more info. 

I have moved the supervision so that actors are added underneath a root supervisor which I will remove before merging. 

Ideally we will make our test suite more modular and less dependent on globals unless directly testing that API. 
