### PR TITLE
multiple at_exit hooks are confusing

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -122,6 +122,10 @@ module Celluloid
       Celluloid::IncidentReporter.supervise_as :default_incident_reporter, STDERR
     end
 
+    def running?
+      internal_pool
+    end
+
     def register_shutdown
       return if @shutdown_registered
       # Terminate all actors at exit
@@ -522,5 +526,8 @@ $CELLULOID_MONITORING = false
 Celluloid.task_class = Celluloid::TaskFiber
 Celluloid.logger     = Logger.new(STDERR)
 Celluloid.shutdown_timeout = 10
-Celluloid.register_shutdown
-Celluloid.init
+
+unless $CELLULOID_TEST
+  Celluloid.register_shutdown
+  Celluloid.init
+end

--- a/lib/celluloid/rspec.rb
+++ b/lib/celluloid/rspec.rb
@@ -8,3 +8,5 @@ module Celluloid
 end
 
 $CELLULOID_DEBUG = true
+
+require 'celluloid/test'

--- a/lib/celluloid/test.rb
+++ b/lib/celluloid/test.rb
@@ -1,0 +1,3 @@
+$CELLULOID_TEST = true
+
+require 'celluloid'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,8 @@ Coveralls.wear!
 
 require 'rubygems'
 require 'bundler/setup'
-require 'celluloid'
-require 'celluloid/probe'
 require 'celluloid/rspec'
+require 'celluloid/probe'
 
 logfile = File.open(File.expand_path("../../log/test.log", __FILE__), 'a')
 logfile.sync = true
@@ -22,10 +21,11 @@ RSpec.configure do |config|
 
   config.before do
     Celluloid.logger = logger
-    Celluloid.shutdown
-    sleep 0.01
-
-    Celluloid.internal_pool.assert_inactive
+    if Celluloid.running?
+      Celluloid.shutdown
+      sleep 0.01
+      Celluloid.internal_pool.assert_inactive
+    end
 
     Celluloid.boot
   end


### PR DESCRIPTION
### Was: How to test (asynchronously) Celluloid::Notifications?

The following test passes when you run `rspec testfile.rb`. But if you run `ruby testfile.rb` you'll get "Celluloid::DeadActorError: notifications fanout actor not running" exception.

How can I keep the test waiting and the actor running? I tried using the `receive` method to keep waiting but without success.

``` ruby
require 'rspec/autorun'
require 'celluloid'

class Foo
  include Celluloid
  include Celluloid::Notifications

  attr_reader :count

  def update_counter(topic, counter)
    @count ||= 0
    @count += counter
  end
end

class Bar
  include Celluloid
  include Celluloid::Notifications

  def increase
    publish('counters', 1)
  end
end

describe Celluloid::Notifications do
  it 'increases the counter' do
    foo = Foo.new
    foo.subscribe('counters', :update_counter)

    bar = Bar.new
    bar.increase

    foo.count.should == 1
  end
end
```
