### PR TITLE
Terminated task logging is useless

### DIFF
--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -113,7 +113,9 @@ module Celluloid
       raise "Cannot terminate an exclusive task" if exclusive?
 
       if running?
-        Celluloid.logger.warn "Terminating task: type=#{@type.inspect}, meta=#{@meta.inspect}, status=#{@status.inspect}"
+        Logger.with_backtrace(backtrace) do |logger|
+          logger.warn "Terminating task: type=#{@type.inspect}, meta=#{@meta.inspect}, status=#{@status.inspect}"
+        end
         exception = Task::TerminatedError.new("task was terminated")
         exception.set_backtrace(caller)
         resume exception

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -415,7 +415,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
 
     it "logs a warning when terminating tasks" do
       Celluloid.logger = double.as_null_object
-      Celluloid.logger.should_receive(:warn).with("Terminating task: type=:call, meta={:method_name=>:sleepy}, status=:sleeping")
+      Celluloid.logger.should_receive(:warn).with(/^Terminating task: type=:call, meta={:method_name=>:sleepy}, status=:sleeping\n/)
 
       actor = actor_class.new "Arnold Schwarzenegger"
       actor.async.sleepy 10


### PR DESCRIPTION
```
[2013-10-02 14:39:18] WARN  Celluloid: Terminating task: type=:call, meta={:method_name=>:run}, status=:iowait
```

Awesome, a task executing the `#run` method as a sync call which hit an IO-wait state was terminated! Where? No idea!
