### PR TITLE
Problems trapping signals: deadlock on 1.9, impossible on 2.0

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -131,6 +131,20 @@ module Celluloid
       actor_system && actor_system.running?
     end
 
+    def trap(signal)
+      r, w = IO.pipe
+
+      Thread.new {
+        while r.read(1)
+          yield
+        end
+      }
+       
+      Signal.trap(signal) {
+        w.write(".")
+      }
+    end
+
     def register_shutdown
       return if @shutdown_registered
       # Terminate all actors at exit

--- a/spec/celluloid/trap_spec.rb
+++ b/spec/celluloid/trap_spec.rb
@@ -10,16 +10,33 @@ class Bikeshed
   end
 end
 
-describe "Celluloid.trap" do
-  it "handles INFO" do
+describe "Celluloid.trap", actor_system: :global do
+  it "handles two signals" do
     shed = Bikeshed.new
+
+    completed = Struct.new(:value).new(:completed)
+
+    green_future = Celluloid::Future.new
+    red_future = Celluloid::Future.new
 
     Celluloid.trap("INFO") do
       shed.paint("green")
+      green_future.signal completed
     end
 
     Process.kill("INFO", $$)
-    
+
+    green_future.value.should == :completed
     shed.color.should == "green"
+
+    Celluloid.trap("USR2") do
+      shed.paint("red")
+      red_future.signal completed
+    end
+
+    Process.kill("USR2", $$)
+
+    red_future.value.should == :completed
+    shed.color.should == "red"
   end
 end

--- a/spec/celluloid/trap_spec.rb
+++ b/spec/celluloid/trap_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+class Bikeshed
+  include Celluloid
+
+  attr_reader :color
+
+  def paint(color)
+    @color = color
+  end
+end
+
+describe "Celluloid.trap" do
+  it "handles INFO" do
+    shed = Bikeshed.new
+
+    Celluloid.trap("INFO") do
+      shed.paint("green")
+    end
+
+    Process.kill("INFO", $$)
+    
+    shed.color.should == "green"
+  end
+end


### PR DESCRIPTION
I'll try take a look at this tomorrow if I get time.

`ruby 1.9.3p286 (2012-10-12 revision 37165) [x86_64-darwin12.2.1]`
`Celluloid 0.12.3`

``` ruby
class Foo
  include Celluloid

  def bar
    sleep 0.1
  end
end

pool = Foo.pool(size: 2)
Signal.trap :HUP, Proc.new { puts pool.size }
puts Process.pid
200.times { pool.async.bar }
```

In another terminal, spam the process with a bunch of HUPs. After ~10 seconds the puts will print, followed by the process exiting (as if I wasn't trapping the signal ???) followed by a deadlock trace.

The deadlock itself is perhaps not so weird, what is weird is that the HUPs appear to cause the process to exit. If you change the HUP block to do something non-celluloid related, then it behaves as expected.

Output: https://gist.github.com/4102620
