### PR TITLE
Not possible to cleanly remove actors from supervision group

### DIFF
--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -106,7 +106,12 @@ module Celluloid
       end
       raise "a group member went missing. This shouldn't be!" unless member
 
-      member.restart(reason)
+      if reason
+        member.restart
+      else
+        member.cleanup
+        @members.delete(member)
+      end
     end
 
     # A member of the group
@@ -141,20 +146,21 @@ module Celluloid
         @registry[@name] = @actor if @name
       end
 
-      def restart(reason)
+      def restart
         @actor = nil
-        @registry.delete(@name) if @name
-
-        # Ignore supervisors that shut down cleanly
-        return unless reason
+        cleanup
 
         start
       end
 
       def terminate
-        @registry.delete(@name) if @name
+        cleanup
         @actor.terminate if @actor
       rescue DeadActorError
+      end
+
+      def cleanup
+        @registry.delete(@name) if @name
       end
     end
   end

--- a/spec/celluloid/supervisor_spec.rb
+++ b/spec/celluloid/supervisor_spec.rb
@@ -89,4 +89,15 @@ describe Celluloid::Supervisor do
     new_subordinate.should_not eq subordinate
     new_subordinate.state.should be(:working)
   end
+
+  it "removes an actor if it terminates cleanly" do
+    supervisor = Subordinate.supervise(:working)
+    subordinate = supervisor.actors.first
+
+    supervisor.actors.should == [subordinate]
+
+    subordinate.terminate
+
+    supervisor.actors.should be_empty
+  end
 end


### PR DESCRIPTION
I am listening to a cluster of servers using Celluloid actors, the cluster can change, so I need to be able to dynamically add and remove actors as servers go up and down, but unless it changes I want the actors to restart if they crash.

I've created a supervision group, which keeps track of which servers need to be watched and I can add actors to this group, unfortunately there isn't a good way to remove actors from the group in case one server goes down. Supervision groups don't seem to have a way to remove actors from their list of members.

Terminating an actor using `terminate` doesn't seem to be safe, since it leaks members in the supervision group.
