### PR TITLE
Fix bug in Supervisors & Registry example

### DIFF
--- a/examples/supervisors_and_registry.rb
+++ b/examples/supervisors_and_registry.rb
@@ -27,8 +27,8 @@ puts "*** Demonstrating using the Supervisor API directly"
 supervisor = MyActor.supervise
 
 # We can get to the current version of an actor by calling
-# Celluloid::Supervisor#actor. This prints ':clean'
-puts "We should be in a clean state now: #{supervisor.actor.state}"
+# Celluloid::Supervisor#actors. This prints ':clean'
+puts "We should be in a clean state now: #{supervisor.actors.first.state}"
 puts "Brace yourself for a crash message..."
 
 # If we call a method that crashes an actor, it will print out a debug message,
@@ -43,7 +43,7 @@ puts "The supervisor should automatically restart the actor"
 
 # By now we'll be back in a :clean state!
 begin
-  puts "We should now be in a clean state again: #{supervisor.actor.state}"
+  puts "We should now be in a clean state again: #{supervisor.actors.first.state}"
 rescue Celluloid::DeadActorError
   # Perhaps we got ahold of the actor before the supervisor restarted it
   retry


### PR DESCRIPTION
The Supervisors and Registry example is not working. I'm seeing two issues.
1. Its calling an undefined method `actor` in two places. I included a potential solution in the pull request. `celluloid/lib/celluloid/calls.rb:30:in 'check': undefined method 'actor' for <Celluloid::CellProxy(Celluloid::SupervisionGroup:0x3fc4c1844340)`
2. Second, `Celluloid::Actor[:my_actor]` on line 78 is returning nil, causing an undefined method `state`. I'm not sure why this is happening.  Inserting a `sleep` on the previous line for any amount of time seems to fix the issue. But perhaps there is a solution that address the root of the issue?

`examples/supervisors_and_registry.rb:78:in '<main>': undefined method 'state' for nil:NilClass (NoMethodError)`

line 78:
 `puts "We should now be in a clean state again: #{Celluloid::Actor[:my_actor].state}"`
