### PR TITLE
Change actor configuration for Task and Mailbox to use symbols

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -123,10 +123,10 @@ module Celluloid
       @behavior         = behavior
 
       @actor_system     = options.fetch(:actor_system)
-      @mailbox          = options.fetch(:mailbox_class, Mailbox).new
+      @mailbox          = Mailbox.build(options.fetch(:mailbox_type))
       @mailbox.max_size = options.fetch(:mailbox_size, nil)
 
-      @task_class   = options[:task_class] || Celluloid.task_class
+      @task_class   = Task.fetch(options[:task_type])
       @exit_handler = method(:default_exit_handler)
       @exclusive    = options.fetch(:exclusive, false)
 

--- a/lib/celluloid/mailbox.rb
+++ b/lib/celluloid/mailbox.rb
@@ -7,6 +7,22 @@ module Celluloid
   # Actors communicate with asynchronous messages. Messages are buffered in
   # Mailboxes until Actors can act upon them.
   class Mailbox
+
+    class << self
+      attr_reader :registry
+    end
+    @registry = {}
+
+    def self.register(type)
+      Mailbox.registry[type] = self
+    end
+
+    def self.build(type)
+      Mailbox.registry.fetch(type).new
+    end
+
+    register :messages
+
     include Enumerable
 
     # A unique address at which this mailbox can be found

--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -14,6 +14,19 @@ module Celluloid
 
     class TimeoutError < ResumableError; end # kill a running task after timeout
 
+    class << self
+      attr_reader :registry
+    end
+    @registry = {}
+
+    def self.register(type)
+      Task.registry[type] = self
+    end
+
+    def self.fetch(type)
+      Task.registry.fetch(type)
+    end
+
     # Obtain the current task
     def self.current
       Thread.current[:celluloid_task] or raise NotTaskError, "not within a task context"

--- a/lib/celluloid/tasks/task_fiber.rb
+++ b/lib/celluloid/tasks/task_fiber.rb
@@ -3,6 +3,7 @@ module Celluloid
 
   # Tasks with a Fiber backend
   class TaskFiber < Task
+    register :fiber
 
     def create
       queue = Thread.current[:celluloid_queue]

--- a/lib/celluloid/tasks/task_thread.rb
+++ b/lib/celluloid/tasks/task_thread.rb
@@ -1,6 +1,8 @@
 module Celluloid
   # Tasks with a Thread backend
   class TaskThread < Task
+    register :thread
+
     # Run the given block within a task
     def initialize(type, meta)
       @resume_queue = Queue.new

--- a/spec/celluloid/stack_dump_spec.rb
+++ b/spec/celluloid/stack_dump_spec.rb
@@ -18,9 +18,9 @@ describe Celluloid::StackDump do
   end
 
   before(:each) do
-    [Celluloid::TaskFiber, Celluloid::TaskThread].each do |task_klass|
+    Celluloid::Task.registry.each do |type,_|
       actor_klass = Class.new(BlockingActor) do
-        task_class task_klass
+        dispatch_with type
       end
       actor = actor_system.within do
         actor_klass.new

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -1,18 +1,17 @@
 shared_examples "a Celluloid Actor" do |included_module|
-  describe "using Fibers" do
-    include_examples "Celluloid::Actor examples", included_module, Celluloid::TaskFiber
-  end
-  describe "using Threads" do
-    include_examples "Celluloid::Actor examples", included_module, Celluloid::TaskThread
+  Celluloid::Task.registry.dup.each do |type,_|
+    describe "dispatching with #{type}" do
+      include_examples "Celluloid::Actor examples", included_module, type
+    end
   end
 end
 
-shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
+shared_examples "Celluloid::Actor examples" do |included_module, task_type|
   class ExampleCrash < StandardError
     attr_accessor :foo
   end
 
-  let(:actor_class) { ExampleActorClass.create(included_module, task_klass) }
+  let(:actor_class) { ExampleActorClass.create(included_module, task_type) }
 
   it "returns the actor's class, not the proxy's" do
     actor = actor_class.new "Troy McClure"
@@ -93,7 +92,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
   it "handles circular synchronous calls" do
     klass = Class.new do
       include included_module
-      task_class task_klass
+      dispatch_with task_type
 
       def greet_by_proxy(actor)
         actor.greet
@@ -112,7 +111,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
   it "detects recursion" do
     klass1 = Class.new do
       include included_module
-      task_class task_klass
+      dispatch_with task_type
 
       def recursion_test(recurse_through = nil)
         if recurse_through
@@ -125,7 +124,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
 
     klass2 = Class.new do
       include included_module
-      task_class task_klass
+      dispatch_with task_type
 
       def recursion_thunk(other)
         other.recursion_test
@@ -154,7 +153,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
   it "warns about suspending the initialize" do
     klass = Class.new do
       include included_module
-      task_class task_klass
+      dispatch_with task_type
 
       def initialize
         sleep 0.1
@@ -179,7 +178,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
   it "warns about suspending the finalizer" do
     klass = Class.new do
       include included_module
-      task_class task_klass
+      dispatch_with task_type
 
       finalizer :cleanup
 
@@ -251,7 +250,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
   it "supports recursive inspect with other actors" do
     klass = Class.new do
       include included_module
-      task_class task_klass
+      dispatch_with task_type
 
       attr_accessor :other
 
@@ -315,7 +314,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     it "includes both sender and receiver in exception traces" do
       ExampleReceiver = Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
 
         def receiver_method
           raise ExampleCrash, "the spec purposely crashed me :("
@@ -324,7 +323,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
 
       ExampleCaller = Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
 
         def sender_method
           ExampleReceiver.new.receiver_method
@@ -460,7 +459,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     let(:supervisor_class) do
       Class.new do # like a boss
         include included_module
-        task_class task_klass
+        dispatch_with task_type
         trap_exit :lambaste_subordinate
 
         def initialize(name)
@@ -555,7 +554,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     before do
       @signaler = Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
 
         def initialize
           @waiting  = false
@@ -613,7 +612,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     subject do
       Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
 
         attr_reader :tasks
 
@@ -680,7 +679,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     subject do
       Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
         exclusive
 
         attr_reader :tasks
@@ -713,7 +712,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     before do
       @receiver = Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
         execute_block_on_receiver :signal_myself
 
         def signal_myself(obj, &block)
@@ -748,7 +747,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     before do
       @klass = Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
 
         def initialize
           @sleeping = false
@@ -853,7 +852,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     before do
       @klass = Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
         attr_reader :blocker
 
         def initialize
@@ -891,7 +890,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
       tasks.size.should be 2
 
       blocking_task = tasks.find { |t| t.status != :running }
-      blocking_task.should be_a task_klass
+      blocking_task.should be_a Celluloid::Task.fetch(task_type)
       blocking_task.status.should be :callwait
 
       actor.blocker.unblock
@@ -900,14 +899,16 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     end
   end
 
-  context :mailbox_class do
-    class ExampleMailbox < Celluloid::Mailbox; end
+  context :mailbox_type do
+    class ExampleMailbox < Celluloid::Mailbox
+      register :example
+    end
 
     subject do
       Class.new do
         include included_module
-        task_class task_klass
-        mailbox_class ExampleMailbox
+        dispatch_with task_type
+        react_to :example
       end
     end
 
@@ -925,7 +926,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     subject do
       Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
         mailbox_size 100
       end
     end
@@ -945,7 +946,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     subject do
       Class.new do
         include included_module
-        task_class task_klass
+        dispatch_with task_type
         proxy_class ExampleProxy
       end
     end
@@ -961,12 +962,14 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
   end
 
   context :task_class do
-    class ExampleTask < Celluloid::TaskFiber; end
+    class ExampleTask < Celluloid::TaskFiber
+      register :example
+    end
 
     subject do
       Class.new do
         include included_module
-        task_class ExampleTask
+        dispatch_with :example
       end
     end
 

--- a/spec/support/example_actor_class.rb
+++ b/spec/support/example_actor_class.rb
@@ -2,7 +2,7 @@ module ExampleActorClass
   def self.create(included_module, task_klass)
     Class.new do
       include included_module
-      task_class task_klass
+      dispatch_with task_type
       attr_reader :name
       finalizer :my_finalizer
       execute_block_on_receiver :run_on_receiver


### PR DESCRIPTION
This change breaks the pre-1.0 API.

Fixes #251 and #262 

/cc @tarcieri @mperham
