### PR TITLE
Celluloid.shutdown does not shut down cleanly when TaskThread is used

### DIFF
--- a/lib/celluloid/actor_system.rb
+++ b/lib/celluloid/actor_system.rb
@@ -64,8 +64,6 @@ module Celluloid
     def shutdown
       actors = running
       Timeout.timeout(shutdown_timeout) do
-        @internal_pool.shutdown
-
         Logger.debug "Terminating #{actors.size} #{(actors.size > 1) ? 'actors' : 'actor'}..." if actors.size > 0
 
         # Actors cannot self-terminate, you must do it for them
@@ -82,6 +80,8 @@ module Celluloid
           rescue DeadActorError
           end
         end
+
+        @internal_pool.shutdown
       end
     rescue Timeout::Error
       Logger.error("Couldn't cleanly terminate all actors in #{shutdown_timeout} seconds!")

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -417,6 +417,15 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
       end.to raise_exception(Celluloid::DeadActorError)
     end
 
+    it "terminates cleanly on Celluloid shutdown" do
+      Celluloid::Actor.stub(:kill).and_call_original
+
+      actor = actor_class.new "Arnold Schwarzenegger"
+
+      Celluloid.shutdown
+      Celluloid::Actor.should_not have_received(:kill)
+    end
+
     it "raises the right DeadActorError if terminate! called after terminated" do
       actor = actor_class.new "Arnold Schwarzenegger"
       actor.terminate


### PR DESCRIPTION
If the Actor has a finalizer and `task_class TaskThread` is used, shutting down Celluloid does not complete cleanly, and the finalizer is not run. Here's a minimal repro:

``` ruby
require "celluloid"
require "logger"

$CELLULOID_DEBUG = true
Celluloid.logger = Logger.new($stdout)

class Mediator
  include Celluloid

  task_class TaskThread

  finalizer :monkey

  def monkey
    # No op.
  end
end

actor = Mediator.new

sleep 1
Celluloid.shutdown
```

This fails on JRuby, MRI and rbx, consistently. Output:

```
~/Projects/celluloid$ ruby -Ilib test.rb
D, [2013-12-10T13:35:34.433723 #35371] DEBUG -- : Terminating 1 actor...
E, [2013-12-10T13:35:44.434688 #35371] ERROR -- : Couldn't cleanly terminate all actors in 10 seconds!
```

In the attached pull request, we've moved the shutdown of the internal pool after the shutdown of the actors. This seems to fix the issue for us, but we're not sure if this has other undesired side-effects. Also, we couldn't run the test suite on JRuby and rbx because we were getting deadlocks (even without our changes).

The test we added consistently fails on all rubies before our change, and consistently passes after.
