### PR TITLE
Add failing spec for supervision group tree

### DIFF
--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -5,6 +5,24 @@ module Celluloid
     trap_exit :restart_actor
 
     class << self
+      def new(registry = nil)
+        super(registry) do |_group|
+          blocks.each do |block|
+            block.call(_group)
+          end
+          yield _group if block_given?
+        end
+      end
+
+      def new_link(registry = nil)
+        super(registry) do |_group|
+          blocks.each do |block|
+            block.call(_group)
+          end
+          yield _group if block_given?
+        end
+      end
+
       # Actors or sub-applications to be supervised
       def blocks
         @blocks ||= []

--- a/spec/celluloid/supervision_group_spec.rb
+++ b/spec/celluloid/supervision_group_spec.rb
@@ -62,4 +62,19 @@ describe Celluloid::SupervisionGroup, actor_system: :global do
       supervisor[:example].should be_a MyActor
     end
   end
+
+  context "supervision group tree" do
+    before :all do
+      class MyParentGroup < Celluloid::SupervisionGroup
+        supervise MyGroup, :as => :my_group
+      end
+    end
+
+    it "starts child-supervised actors" do
+      MyParentGroup.run!
+      sleep 0.001
+
+      Celluloid::Actor[:example].should be_running
+    end
+  end
 end

--- a/spec/celluloid/supervision_group_spec.rb
+++ b/spec/celluloid/supervision_group_spec.rb
@@ -34,36 +34,7 @@ describe Celluloid::SupervisionGroup, actor_system: :global do
     Celluloid::Actor[:example].should be_nil
   end
 
-  context "pool" do
-    before :all do
-      class MyActor
-        attr_reader :args
-        def initialize *args
-          @args = *args
-        end
-      end
-      class MyGroup
-        pool MyActor, :as => :example_pool, :args => 'foo', :size => 3
-      end
-    end
-
-    it "runs applications and passes pool options and actor args" do
-      MyGroup.run!
-      sleep 0.001 # startup time hax
-
-      Celluloid::Actor[:example_pool].should be_running
-      Celluloid::Actor[:example_pool].args.should eq ['foo']
-      Celluloid::Actor[:example_pool].size.should be 3
-    end
-
-    it "allows external access to the internal registry" do
-      supervisor = MyGroup.run!
-
-      supervisor[:example].should be_a MyActor
-    end
-  end
-
-  context "supervision group tree" do
+  context "within nested supervisors" do
     before :all do
       class MyParentGroup < Celluloid::SupervisionGroup
         supervise MyGroup, :as => :my_group
@@ -75,6 +46,52 @@ describe Celluloid::SupervisionGroup, actor_system: :global do
       sleep 0.001
 
       Celluloid::Actor[:example].should be_running
+    end
+  end
+
+  context "pool" do
+    before :all do
+      class MyPoolActor < MyActor
+        attr_reader :args
+        def initialize *args
+          @args = *args
+        end
+      end
+      class MyPoolGroup < Celluloid::SupervisionGroup
+        pool MyPoolActor, :as => :example_pool, :args => 'foo', :size => 3
+      end
+    end
+
+    it "runs applications and passes pool options and actor args" do
+      MyPoolGroup.run!
+      sleep 0.001 # startup time hax
+
+      Celluloid::Actor[:example_pool].should be_running
+      Celluloid::Actor[:example_pool].args.should eq ['foo']
+      Celluloid::Actor[:example_pool].size.should be 3
+    end
+
+    it "allows external access to the internal registry" do
+      supervisor = MyPoolGroup.run!
+
+      supervisor[:example_pool].should be_a MyPoolActor
+    end
+
+    context "within nested supervisors" do
+      before :all do
+        class MyParentPoolGroup < Celluloid::SupervisionGroup
+          pool MyPoolGroup, :as => :my_group
+        end
+      end
+
+      it "starts child-supervised actors" do
+        MyParentPoolGroup.run!
+        sleep 0.001
+
+        Celluloid::Actor[:example_pool].should be_running
+        Celluloid::Actor[:example_pool].args.should eq ['foo']
+        Celluloid::Actor[:example_pool].size.should be 3
+      end
     end
   end
 end


### PR DESCRIPTION
Tested against JRuby 1.7.8 and 1.7.9, in both cases the actor supervised by a child supervision group doesn't seem be started, and isn't in `Celluloid::Actor.all`. Tested against b9c73fd1


Celluloid::SupervisionGroup
  runs applications
  accepts a private actor registry
  removes actors from the registry when terminating
  pool
    runs applications and passes pool options and actor args
    allows external access to the internal registry
  supervision group tree
    starts child-supervised actors (FAILED - 1)

Failures:

  1) Celluloid::SupervisionGroup supervision group tree starts child-supervised actors
     Failure/Error: Celluloid::Actor[:example].should be_running
     NoMethodError:
       undefined method `running?' for nil:NilClass
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-expectations-2.14.4/lib/rspec/matchers/built_in/be.rb:145:in `matches?'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-expectations-2.14.4/lib/rspec/expectations/handler.rb:24:in `handle_matcher'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-expectations-2.14.4/lib/rspec/expectations/syntax.rb:53:in `should'
     # ./spec/celluloid/supervision_group_spec.rb:81:in `(root)'
     # org/jruby/RubyBasicObject.java:1536:in `instance_eval'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:114:in `run'
     # org/jruby/RubyProc.java:271:in `call'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:179:in `run'
     # ./spec/spec_helper.rb:35:in `(root)'
     # org/jruby/RubyBasicObject.java:1565:in `instance_exec'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:247:in `instance_eval_with_args'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/hooks.rb:106:in `run'
     # org/jruby/RubyProc.java:271:in `call'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:179:in `run'
     # ./spec/spec_helper.rb:30:in `(root)'
     # org/jruby/RubyBasicObject.java:1565:in `instance_exec'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/extensions/instance_eval_with_args.rb:16:in `instance_eval_with_args'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:247:in `instance_eval_with_args'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/hooks.rb:106:in `run'
     # org/jruby/RubyProc.java:271:in `call'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/hooks.rb:104:in `run'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:340:in `run_around_each_hooks'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:256:in `with_around_each_hooks'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example.rb:111:in `run'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:390:in `run_examples'
     # org/jruby/RubyArray.java:2409:in `map'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:386:in `run_examples'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:371:in `run'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `run'
     # org/jruby/RubyArray.java:2409:in `map'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/example_group.rb:372:in `run'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `run'
     # org/jruby/RubyArray.java:2409:in `map'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:28:in `run'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:58:in `report'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:25:in `run'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'
     # /home/doug/.gem/jruby/1.9.3/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:17:in `autorun'

Finished in 0.242 seconds
6 examples, 1 failure

Failed examples:

rspec ./spec/celluloid/supervision_group_spec.rb:77 # Celluloid::SupervisionGroup supervision group tree starts child-supervised actors
