### PR TITLE
Travis - Ruby 2.1.0, fix Rubinius build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,18 @@ script: rake ci
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
   - jruby-19mode
   - jruby-head
-  - rbx-19mode 
+  - rbx
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-19mode # broken :( to be fixed in jruby 1.7.5?!!!
     - rvm: jruby-head
-    - rvm: rbx-19mode # deadlocks :(
+    - rvm: rbx # deadlocks :(
 
 notifications:
   irc: "irc.freenode.org#celluloid"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,13 @@ gemspec
 gem 'coveralls', require: false
 gem 'pry'
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'json'
+  gem 'rubinius-developer_tools'
+end
+
+
 if RUBY_PLATFORM =~ /darwin/
   gem 'rb-fsevent', '~> 0.9.1'
 end


### PR DESCRIPTION
1. Added Ruby 2.1.0 as a non-allowed failure, as this is now a released Ruby
2. Fixed the rbx build by adding required gems, fixing the label in the .travis.yml

On a related note, there definitely appears to be a transient failure with Ruby 1.9.3 - sometimes it fails, sometimes it succeeds.  Probably requires some investigation.

I'm assuming the JRuby failures are known, based on JRuby being an allowed_failure in the test matrix.

Rubinius now passes reliably, so if desired it can be pulled out of the allowed_failures.
