### PR TITLE
Pooled fibers

### DIFF
--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -152,3 +152,4 @@ end
 
 require 'celluloid/tasks/task_fiber'
 require 'celluloid/tasks/task_thread'
+require 'celluloid/tasks/task_pooled_fiber'

--- a/lib/celluloid/tasks/task_pooled_fiber.rb
+++ b/lib/celluloid/tasks/task_pooled_fiber.rb
@@ -1,0 +1,56 @@
+module Celluloid
+
+  class FiberPool
+    def acquire(&block)
+      # If the fiber pool has grown too much, shift off and discard
+      # extra fibers so they may be GC'd. This isn't ideal, but it
+      # should guard against runaway resource consumption.
+      fiber_pool.shift while fiber_pool.length > 10
+      fiber = fiber_pool.shift || create_fiber
+      fiber.resume(block)
+      fiber
+    end
+
+    def create_fiber
+      fiber_pool = self.fiber_pool
+      Fiber.new do |blk|
+        loop do
+          # At this point, we have a pooled fiber ready for Celluloid to call #resume on.
+          Fiber.yield
+
+          # Once Celluloid resumes the fiber, we need to execute the block the task was
+          # created with. This may call suspend/resume; that's fine.
+          blk.call
+
+          # Once Celluloid completes the task, we release this Fiber back to the pool
+          fiber_pool << Fiber.current
+
+          # ...and yield for the next #acquire call.
+          blk = Fiber.yield
+        end
+      end
+    end
+
+    # Fiber pool for this thread. Fibers can't cross threads, so we have to maintain a
+    # pool per thread.
+    def fiber_pool
+      Thread.current[:celluloid_task_fiber_pool] ||= []
+    end
+  end
+
+  # Tasks with a pooled Fiber backend
+  class TaskPooledFiber < TaskFiber
+    def self.fiber_pool
+      @fiber_pool ||= FiberPool.new
+    end
+
+    def create(&block)
+      queue = Thread.current[:celluloid_queue]
+      @fiber = TaskPooledFiber.fiber_pool.acquire {
+        Thread.current[:celluloid_role] = :actor
+        Thread.current[:celluloid_queue] = queue
+        block.call
+      }
+    end
+  end
+end

--- a/lib/celluloid/tasks/task_pooled_fiber.rb
+++ b/lib/celluloid/tasks/task_pooled_fiber.rb
@@ -1,18 +1,29 @@
 module Celluloid
 
   class FiberPool
+    attr_accessor :stats
+
+    def initialize(trim_size = 25)
+      @trim_size = 25
+      @pool = {}
+      @stats = {:created => 0, :acquired => 0, :trimmed => 0, :sweep_counter => 0, :terminated => 0, :terminated_threads => 0, :sweeps => 0}
+      @mutex = Mutex.new
+    end
+
     def acquire(&block)
-      # If the fiber pool has grown too much, shift off and discard
-      # extra fibers so they may be GC'd. This isn't ideal, but it
-      # should guard against runaway resource consumption.
-      fiber_pool.shift while fiber_pool.length > 10
+      trim
+      sweep
+      @stats[:acquired] += 1
       fiber = fiber_pool.shift || create_fiber
       fiber.resume(block)
       fiber
     end
 
+    private
+
     def create_fiber
-      fiber_pool = self.fiber_pool
+      pool = fiber_pool
+      @stats[:created] += 1
       Fiber.new do |blk|
         loop do
           # At this point, we have a pooled fiber ready for Celluloid to call #resume on.
@@ -23,18 +34,61 @@ module Celluloid
           blk.call
 
           # Once Celluloid completes the task, we release this Fiber back to the pool
-          fiber_pool << Fiber.current
+          pool << Fiber.current
 
           # ...and yield for the next #acquire call.
           blk = Fiber.yield
+          break if blk == :terminate
+        end
+      end
+    end
+
+    # If the fiber pool has grown too much, shift off and discard
+    # extra fibers so they may be GC'd. This isn't ideal, but it
+    # should guard against runaway resource consumption.
+    def trim
+      pool = fiber_pool
+      while pool.length > @trim_size
+        @stats[:trimmed] += 1
+        pool.shift.resume(:terminate)
+      end
+    end
+
+    def sweep
+      @mutex.synchronize do
+        @stats[:sweep_counter] += 1
+        if @stats[:sweep_counter] > 10_000
+          alive = []
+          Thread.list.each do |thread|
+            alive << thread.object_id if thread.alive? && @pool.key?(thread.object_id)
+          end
+
+          (@pool.keys - alive).each do |thread_id|
+            @pool[thread_id].each do |fiber|
+              @stats[:terminated] += 1
+              # We can't resume the fiber here because we might resume cross-thread
+              # TODO: How do we deal with alive fibers in a dead thread?
+              # fiber.resume(:terminate)
+            end
+            @stats[:terminated_threads] += 1
+            @pool.delete thread_id
+          end
+          @stats[:sweep_counter] = 0
+          @stats[:sweeps] += 1
         end
       end
     end
 
     # Fiber pool for this thread. Fibers can't cross threads, so we have to maintain a
     # pool per thread.
+    #
+    # We keep our pool in an instance variable rather than in thread locals so that we
+    # can sweep out old Fibers from dead threads. This keeps live Fiber instances in
+    # a thread local from keeping the thread from being GC'd.
     def fiber_pool
-      Thread.current[:celluloid_task_fiber_pool] ||= []
+      @mutex.synchronize do
+        @pool[Thread.current.object_id] ||= []
+      end
     end
   end
 

--- a/spec/celluloid/tasks/task_pooled_fiber_spec.rb
+++ b/spec/celluloid/tasks/task_pooled_fiber_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Celluloid::TaskPooledFiber, actor_system: :within do
+  it_behaves_like "a Celluloid Task", Celluloid::TaskPooledFiber
+end


### PR DESCRIPTION
(Recreated based off of master now)

This adds support for a variant on TaskFiber which pools fibers for a given thread. This is primarily a triage patch for JRuby 1.7.5+ which isn't currently pooling the threads that back its fibers, resulting in a ridonkulous amount of CPU burn as it spins up a new thread per Fiber. See jruby/jruby#1443 for full details there.

This is the same fiber pattern used by rack-fiber_pool, among others. In my tests, it's completely eliminated the JRuby CPU thrashing, and actually improved performance of Celluloid under MRI, too.

Using [this very unrigorous benchmark](https://gist.github.com/cheald/94097ddb2a855cdb2583), I saw the following results:

|              | TaskFiber           | TaskPooledFiber |
|--------------|---------------------|-----------------|
| 2.0.0-p247   | 4.08 sec            | 2.79 sec        |
| jruby-1.7.10 | 29.5 sec (not a typo) | 5.04 sec        |
