### PR TITLE
Don't use null object as logger in tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'celluloid/probe'
 logfile = File.open(File.expand_path("../../log/test.log", __FILE__), 'a')
 logfile.sync = true
 
-logger = Celluloid.logger = Logger.new(logfile)
+Celluloid.logger = Logger.new(logfile)
 
 Celluloid.shutdown_timeout = 1
 
@@ -20,7 +20,6 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.around do |ex|
-    Celluloid.logger = logger
     Celluloid.actor_system = nil
     Thread.list.each do |thread|
       next if thread == Thread.current

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -161,7 +161,6 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
       end
     end
 
-    Celluloid.logger = double.as_null_object
     Celluloid.logger.should_receive(:warn).with(/Dangerously suspending task: type=:call, meta={:method_name=>:initialize}, status=:sleeping/)
 
     actor = klass.new
@@ -188,7 +187,6 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
       end
     end
 
-    Celluloid.logger = double.as_null_object
     Celluloid.logger.should_receive(:warn).with(/Dangerously suspending task: type=:finalizer, meta={:method_name=>:cleanup}, status=:sleeping/)
 
     actor = klass.new
@@ -436,7 +434,6 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     end
 
     it "logs a warning when terminating tasks" do
-      Celluloid.logger = double.as_null_object
       Celluloid.logger.should_receive(:warn).with(/^Terminating task: type=:call, meta={:method_name=>:sleepy}, status=:sleeping\n/)
 
       actor = actor_class.new "Arnold Schwarzenegger"
@@ -1022,7 +1019,6 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
 
   context "raw message sends" do
     it "logs on unhandled messages" do
-      Celluloid.logger = double.as_null_object
       Celluloid.logger.should_receive(:debug).with("Discarded message (unhandled): first")
 
       actor = actor_class.new "Irma Gladden"

--- a/spec/support/mailbox_examples.rb
+++ b/spec/support/mailbox_examples.rb
@@ -58,7 +58,6 @@ shared_context "a Celluloid Mailbox" do
   end
 
   it "logs discarded messages" do
-    Celluloid.logger = double.as_null_object
     Celluloid.logger.should_receive(:debug).with("Discarded message (mailbox is dead): third")
 
     subject.max_size = 2
@@ -68,7 +67,6 @@ shared_context "a Celluloid Mailbox" do
   end
 
   it "discard messages when dead" do
-    Celluloid.logger = double.as_null_object
     Celluloid.logger.should_receive(:debug).with("Discarded message (mailbox is dead): first")
     Celluloid.logger.should_receive(:debug).with("Discarded message (mailbox is dead): second")
     Celluloid.logger.should_receive(:debug).with("Discarded message (mailbox is dead): third")


### PR DESCRIPTION
It seems that null objects don't handle `warn` properly, sometimes, or something. This was causing lots of stuff to be printed to stderr in celluloid-zmq's tests. It isn't really necessary to use a null object, we can simply make an assertion on the actual logger object. We've defined the logger to log to a special fine in the spec_helper anyway. This also removes the need to reset the logger in an around filter, which is nice.
