### PR TITLE
Silence const redefinition warning by using a local variable for the class instead

### DIFF
--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -313,27 +313,27 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
     end
 
     it "includes both sender and receiver in exception traces" do
-      ExampleReceiver = Class.new do
+      example_receiver = Class.new do
         include included_module
         task_class task_klass
 
-        def receiver_method
+        define_method(:receiver_method) do
           raise ExampleCrash, "the spec purposely crashed me :("
         end
       end
 
-      ExampleCaller = Class.new do
+      excample_caller = Class.new do
         include included_module
         task_class task_klass
 
-        def sender_method
-          ExampleReceiver.new.receiver_method
+        define_method(:sender_method) do
+          example_receiver.new.receiver_method
         end
       end
 
       ex = nil
       begin
-        ExampleCaller.new.sender_method
+        excample_caller.new.sender_method
       rescue => ex
       end
 


### PR DESCRIPTION
Just a small fix for nicer test output.
