### PR TITLE
Shut down mailbox after each example

### DIFF
--- a/spec/support/mailbox_examples.rb
+++ b/spec/support/mailbox_examples.rb
@@ -1,4 +1,9 @@
 shared_context "a Celluloid Mailbox" do
+  after do
+    Celluloid.logger.stub(:debug)
+    subject.shutdown if subject.alive?
+  end
+
   it "receives messages" do
     message = :ohai
 


### PR DESCRIPTION
This is needed for celluloid-zmq, since we want to be able to close the ZMQ context, which hangs if the Mailbox isn't shut down properly.

I'm not super excited about the `Celluloid.logger.stub` line, but I couldn't come up with a better way of resetting the expectation.
