### PR TITLE
Explain that TaskFiber backtraces are not available instead of just silently hiding them

### DIFF
--- a/lib/celluloid/tasks/task_fiber.rb
+++ b/lib/celluloid/tasks/task_fiber.rb
@@ -35,5 +35,9 @@ module Celluloid
     rescue FiberError
       # If we're getting this the task should already be dead
     end
+
+    def backtrace
+      "#{self.class} backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here."
+    end
   end
 end


### PR DESCRIPTION
See #379
