### PR TITLE
added spec which specifies the issue of reactor crashing when Kernel.tim...

### DIFF
--- a/spec/celluloid/evented_mailbox_spec.rb
+++ b/spec/celluloid/evented_mailbox_spec.rb
@@ -31,4 +31,15 @@ end
 describe Celluloid::EventedMailbox do
   subject { TestEventedMailbox.new }
   it_behaves_like "a Celluloid Mailbox"
+  it "recovers from timeout exceeded to process mailbox message" do
+    timeout_interval = Celluloid::TIMER_QUANTUM + 0.1
+    expect do
+      Kernel.send(:timeout, timeout_interval) do
+        subject.receive { false }
+      end
+    end.to raise_exception(Celluloid::TimeoutError)
+
+    (Time.now - started_at).should be_within(Celluloid::TIMER_QUANTUM).of interval
+  end
+
 end


### PR DESCRIPTION
...eout blows (this spec fails)

This merge request is related to the issue from: https://github.com/celluloid/celluloid-io/pull/98#issuecomment-34047478