### PR TITLE
Using timers instead of Time.now in EventedMailbox

### DIFF
--- a/lib/celluloid/evented_mailbox.rb
+++ b/lib/celluloid/evented_mailbox.rb
@@ -46,13 +46,14 @@ module Celluloid
       until message
         if timeout
           @timers.after(timeout) {
-            raise(TimeoutError, "mailbox timeout exceeded", nil)
+            message = next_message(block)
+            raise(TimeoutError, "mailbox timeout exceeded", nil) if message.nil?
           }
+          @timers.wait
+        else
+          message = next_message(block)
         end
-        @timers.wait
-        message = next_message(block)
       end
-
       message
     rescue IOError
       raise MailboxShutdown, "mailbox shutdown called during receive"


### PR DESCRIPTION
Reading the code and found an easy todo. I hope it's well implemented, if not, I'll correct.
