### PR TITLE
Fix finalizer placement

### DIFF
--- a/lib/celluloid/supervision_group.rb
+++ b/lib/celluloid/supervision_group.rb
@@ -5,7 +5,6 @@ module Celluloid
     trap_exit :restart_actor
 
     class << self
-      finalizer :finalize
 
       # Actors or sub-applications to be supervised
       def blocks
@@ -56,6 +55,8 @@ module Celluloid
         end
       end
     end
+
+    finalizer :finalize
 
     # Start the group
     def initialize(registry = nil)


### PR DESCRIPTION
Fix build failure for b6f0585 caused by moving the finalizer to the eigenclass.
