### PR TITLE
Use shorthand notation for each instead.

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -347,7 +347,7 @@ module Celluloid
         end
       end
 
-      tasks.to_a.each { |task| task.terminate }
+      tasks.to_a.each(&:terminate)
     rescue => ex
       # TODO: metadata
       Logger.crash("CLEANUP CRASHED!", ex)


### PR DESCRIPTION
I am not sure if you normally accept pull requests like this one, but I'd like to change this line to use the shorthand notation for `each` like the codebase does in several other places for `map`, `select` and so forth.
