### PR TITLE
Rescue EINTR for discussion purposes only

### DIFF
--- a/lib/celluloid/cpu_counter.rb
+++ b/lib/celluloid/cpu_counter.rb
@@ -4,7 +4,11 @@ module Celluloid
   module CPUCounter
     case RbConfig::CONFIG['host_os'][/^[A-Za-z]+/]
     when 'darwin'
-      @cores = Integer(`/usr/sbin/sysctl hw.ncpu`[/\d+/])
+      begin
+        @cores = Integer(`/usr/sbin/sysctl hw.ncpu`[/\d+/])
+      rescue Errno::EINTR
+        @cores = nil
+      end
     when 'linux'
       @cores = if File.exists?("/sys/devices/system/cpu/present")
         File.read("/sys/devices/system/cpu/present").split('-').last.to_i+1


### PR DESCRIPTION
We're using sucker_punch in our rails apps and see the following error fairly frequently in dev mode:

```
16:10:56 web.1              | I, [2014-03-27T16:10:56.150167 #3728]  INFO -- : Refreshing Gem list
16:10:57 web.1              | /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:7:in ``': Interrupted system call - /usr/sbin/sysctl (Errno::EINTR)
16:10:57 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:7:in `<module:CPUCounter>'
16:10:58 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:4:in `<module:Celluloid>'
16:10:58 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:3:in `<top (required)>'
16:10:58 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/activesupport-4.0.4/lib/active_support/dependencies.rb:229:in `require'
16:10:58 web.1              | exited with code 1
```

Having almost zero knowledge of the interworkings of this codebase, the patch included is not intended as a solution, but as a point of discussion:
- What does this error mean for the proper functioning of celluloid?
- Can/Should it be trapped (obviously in a cleaner way that what I'm showing here)?
- What happens if `@cores` is `nil`?  Is that an acceptable fallback as opposed to just crashing during a `require`?

If the answer is "yeah, it's cool to trap this and do something sensible by default" I will make a real change to the code better than this.  If the answer is "dear lord do _not_ do that", I'd appreciate any help in debugging this and/or avoiding this problem…
