### PR TITLE
Dont die querying cores during a require

### DIFF
--- a/lib/celluloid/cpu_counter.rb
+++ b/lib/celluloid/cpu_counter.rb
@@ -25,6 +25,13 @@ module Celluloid
       else
         @cores = nil
       end
+    rescue => ex
+      if ENV['CELLULOID_IGNORE_CORE_COUNTING_ERRORS'] == 'true'
+        $stderr.puts(ex.message + "; ignoring and setting cores to nil")
+        @cores = nil
+      else
+        raise 
+      end
     end
 
   end


### PR DESCRIPTION
A better PR for the problem identified in #405.

I'm seeing three developer machines (all latest OS X + latest foreman + latest celluloid), experience this frequently when starting our app (that is using sucker punch):

```
16:10:56 web.1              | I, [2014-03-27T16:10:56.150167 #3728]  INFO -- : Refreshing Gem list
16:10:57 web.1              | /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:7:in ``': Interrupted system call - /usr/sbin/sysctl (Errno::EINTR)
16:10:57 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:7:in `<module:CPUCounter>'
16:10:58 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:4:in `<module:Celluloid>'
16:10:58 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/celluloid-0.15.2/lib/celluloid/cpu_counter.rb:3:in `<top (required)>'
16:10:58 web.1              |   from /Users/davec/.rvm/gems/ruby-2.1.0@spectre/gems/activesupport-4.0.4/lib/active_support/dependencies.rb:229:in `require'
16:10:58 web.1              | exited with code 1
```

It happens so frequently that I either have to run `foreman` in a loop or hack the install just to get my app to start.

I _believe_ that setting `@cores` to nil is not fatal and not a big deal, so this PR does a couple things to fix this:
1. Changes it to lazy-load instead of loading on `require`.  Running real code on a `require` creates these sorts of troubles
2. Adds test coverage now that the code can be called outside the file loading process
3. Adds a generic exception handler, active only if the environment variable `CELLULOID_IGNORE_CORE_COUNTING_ERRORS` is set to `true`, that just eats the error.

Lastly, I know almost _nothing_ about celluloid—we're only using it as a dependency of sucker punch right now, so please correct me if this is Totally Wrong™ or otherwise bad.

Will throw a few comments in the code to explain my thinking more.
