### PR TITLE
treat TerminationRequest as SystemEvent

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -189,7 +189,7 @@ module Celluloid
             return
           elsif message.instance_of? NilClass
             raise TimeoutError, "linking timeout of #{LINKING_TIMEOUT} seconds exceeded"
-          elsif message.instance_of? SystemEvent
+          elsif message.is_a? SystemEvent
             # Queue up pending system events to be processed after we've successfully linked
             system_events << message
           else raise 'wtf'


### PR DESCRIPTION
TerminationRequest < SystemEvent, so the 'instance_of?' was a mistake.

What I got:

```
RuntimeError "wtf"
```

and a stack trace:

```
/home/bsd/stuff/celluloid/lib/celluloid/actor.rb:197:in `block (2 levels) in linking_request'
/home/bsd/stuff/celluloid/lib/celluloid/actor.rb:177:in `loop'
/home/bsd/stuff/celluloid/lib/celluloid/actor.rb:177:in `block in linking_request'
/home/bsd/stuff/celluloid/lib/celluloid/tasks.rb:104:in `exclusive'
/home/bsd/stuff/celluloid/lib/celluloid.rb:414:in `exclusive'
/home/bsd/stuff/celluloid/lib/celluloid/actor.rb:172:in `linking_request'
/home/bsd/stuff/celluloid/lib/celluloid/actor.rb:56:in `monitor'
/home/bsd/stuff/celluloid/lib/celluloid/actor.rb:67:in `link'
/home/bsd/stuff/celluloid/lib/celluloid.rb:179:in `new_link'
/home/bsd/stuff/celluloid/lib/celluloid/supervision_group.rb:141:in `start'
/home/bsd/stuff/celluloid/lib/celluloid/supervision_group.rb:129:in `initialize'
/home/bsd/stuff/celluloid/lib/celluloid/supervision_group.rb:85:in `new'
/home/bsd/stuff/celluloid/lib/celluloid/supervision_group.rb:85:in `add'
/home/bsd/stuff/celluloid/lib/celluloid/calls.rb:26:in `public_send'
/home/bsd/stuff/celluloid/lib/celluloid/calls.rb:26:in `dispatch'
/home/bsd/stuff/celluloid/lib/celluloid/calls.rb:63:in `dispatch'
/home/bsd/stuff/celluloid/lib/celluloid/cell.rb:60:in `block in invoke'
/home/bsd/stuff/celluloid/lib/celluloid/cell.rb:71:in `block in task'
/home/bsd/stuff/celluloid/lib/celluloid/actor.rb:364:in `block in task'
/home/bsd/stuff/celluloid/lib/celluloid/tasks.rb:55:in `block in initialize'
/home/bsd/stuff/celluloid/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'
(celluloid):0:in `remote procedure call'
/home/bsd/stuff/celluloid/lib/celluloid/calls.rb:92:in `value'
/home/bsd/stuff/celluloid/lib/celluloid/proxies/sync_proxy.rb:33:in `method_missing'
```

I wanted to write a test, but I couldn't wrap my head around how to setup a test with monitor() calls to reproduce the problem - as a TerminationRequest (couldn't find similar tests, either).
