### PR TITLE
More detailed error message on unexpected message type

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -192,7 +192,7 @@ module Celluloid
           elsif message.is_a? SystemEvent
             # Queue up pending system events to be processed after we've successfully linked
             system_events << message
-          else raise 'wtf'
+          else raise "Unexpected message type: #{message.class}. Expected LinkingResponse, NilClass, SystemEvent."
           end
         end
       end


### PR DESCRIPTION
This error throws from time to time in our specs. We suspect it's a race condition, but it'd be nice to have some more detail in the message when it fires.
