### PR TITLE
Rework core detecting

### DIFF
--- a/spec/celluloid/cpu_counter_spec.rb
+++ b/spec/celluloid/cpu_counter_spec.rb
@@ -23,22 +23,21 @@ describe Celluloid::CPUCounter do
 
     let(:num_cores) { 1024 }
 
-    shared_context "can optionally ignore unexpected conditions" do
-      before do
-        Celluloid::CPUCounter.stub(:`).and_raise(Errno::EINTR)
-        File.stub(:exists?).and_raise(Errno::EACCES)
-        ENV['CELLULOID_IGNORE_CORE_COUNTING_ERRORS'] = nil
-      end
-      context "when we do not want to blow up" do
+    shared_context "handling unexpected errors" do
+      context "with unexpected errors during system calls" do
         before do
-          ENV['CELLULOID_IGNORE_CORE_COUNTING_ERRORS'] = 'true'
-          $stderr.should_receive(:puts)
+          # blow up on systems using sysctl
+          Celluloid::CPUCounter.stub(:`).and_raise(Errno::EINTR)
+
+          # blow up on systems using files
+          File.stub(:exists?).and_raise(Errno::EACCES)
+          ::IO.stub(:read).and_raise(Errno::EACCES)
+          ::IO.stub(:open).and_raise(Errno::EACCES)
+
+          # empty string to blow up Integer() call
+          ENV["NUMBER_OF_PROCESSORS"] = ""
         end
-        it "returns nil instead of blowing up" do
-          Celluloid::CPUCounter.cores.should == nil
-        end
-      end
-      context "by default, when we do want to blow up" do
+
         it "blows up" do
           expect {
             Celluloid::CPUCounter.cores
@@ -51,54 +50,53 @@ describe Celluloid::CPUCounter do
       let(:fake_host_os) { 'darwin' }
       context "when everything is OK" do
         it "uses sysctl" do
-          Celluloid::CPUCounter.should_receive(:`).with("/usr/sbin/sysctl hw.ncpu").and_return("hw.ncpu: #{num_cores}")
+          Celluloid::CPUCounter.should_receive(:`).with("/usr/sbin/sysctl -n hw.ncpu").and_return("hw.ncpu: #{num_cores}")
           Celluloid::CPUCounter.cores.should == num_cores
         end
       end
-      include_context "can optionally ignore unexpected conditions"
+      include_context "handling unexpected errors"
     end
     context 'linux' do
       let(:fake_host_os) { 'linux' }
       context "when /sys/devices/system/cpu/present exists" do
         it "reads CPU info from there" do
-          File.should_receive(:exists?).with("/sys/devices/system/cpu/present").and_return(true)
-          File.should_receive(:read).with("/sys/devices/system/cpu/present").and_return("dunno-whatever-#{num_cores - 1}")
+          ::IO.should_receive(:read).with("/sys/devices/system/cpu/present").and_return("dunno-whatever-#{num_cores - 1}")
           Celluloid::CPUCounter.cores.should == num_cores
         end
       end
       context "when /sys/devices/system/cpu/present does NOT exists" do
         it "counts the number of cpu entries in /sys/devices/system/cpu/" do
-          File.should_receive(:exists?).with("/sys/devices/system/cpu/present").and_return(false)
+          ::IO.should_receive(:read).with("/sys/devices/system/cpu/present").and_raise(Errno::ENOENT)
           cpu_entries = (1..num_cores).map { |n| "cpu#{n}" } + ["non-cpu-entry-to-ignore"]
           Dir.should_receive(:[]).with("/sys/devices/system/cpu/cpu*").and_return(cpu_entries)
           Celluloid::CPUCounter.cores.should == num_cores
         end
       end
-      include_context "can optionally ignore unexpected conditions"
+      include_context "handling unexpected errors"
     end
-    context 'mingw' do
-      let(:fake_host_os) { 'mingw' }
-      it "uses the environment" do
-        ENV["NUMBER_OF_PROCESSORS"] = num_cores.to_s
-        Celluloid::CPUCounter.cores.should == num_cores
-      end
-    end
-    context 'mswin' do
-      let(:fake_host_os) { 'mswin' }
-      it "uses the environment" do
-        ENV["NUMBER_OF_PROCESSORS"] = num_cores.to_s
-        Celluloid::CPUCounter.cores.should == num_cores
-      end
-    end
-    context 'freebsd' do
-      let(:fake_host_os) { 'freebsd' }
-      context "when everything is OK" do
-        it "uses sysctl" do
-          Celluloid::CPUCounter.should_receive(:`).with("sysctl hw.ncpu").and_return("hw.ncpu: #{num_cores}")
-          Celluloid::CPUCounter.cores.should == num_cores
+    %w(mingw mswin cygwin).each do |win_os|
+      context win_os do
+        let(:fake_host_os) { win_os }
+        context "when everything is OK" do
+          it "uses the environment" do
+            ENV["NUMBER_OF_PROCESSORS"] = num_cores.to_s
+            Celluloid::CPUCounter.cores.should == num_cores
+          end
         end
+        include_context "handling unexpected errors"
       end
-      include_context "can optionally ignore unexpected conditions"
+    end
+    %w(freebsd openbsd dragonfly).each do |bsd|
+      context bsd do
+        let(:fake_host_os) { bsd }
+        context "when everything is OK" do
+          it "uses sysctl" do
+            Celluloid::CPUCounter.should_receive(:`).with("/sbin/sysctl -n hw.ncpu").and_return(num_cores.to_s)
+            Celluloid::CPUCounter.cores.should == num_cores
+          end
+        end
+        include_context "handling unexpected errors"
+      end
     end
     context 'ENCOM OS-12' do
       let(:fake_host_os) { 'encom_os-12' }


### PR DESCRIPTION
Bugfixes:
- handle case when NUMBER_OF_PROCESSORS is empty string

Features:
- support using NUMBER_OF_PROCESSORS to override detection on EVERY os
- handle *BSD group along with Dragonfly BSD

Minor cleanup / tweaks / improvements:
- avoid setting @cores if it's going to be returned anyway
- use IO.read + exception handling instead of File.exist?
- group tests by os type
- test showing error (stderr)
- use sysctl '-n' parameter to make things more robust
