### PR TITLE
Map the futures during Pool#__shutdown__, not the actors themselves

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -24,7 +24,7 @@ module Celluloid
     end
 
     def __shutdown__
-      terminators = (@idle + @busy).each do |actor|
+      terminators = (@idle + @busy).map do |actor|
         begin
           actor.future(:terminate)
         rescue DeadActorError


### PR DESCRIPTION
Terminators should be a collection of the actor futures, not the actors themselves.
