### PR TITLE
If the backtrace is not an array, it crashes.

### DIFF
--- a/lib/celluloid/tasks/task_fiber.rb
+++ b/lib/celluloid/tasks/task_fiber.rb
@@ -37,7 +37,7 @@ module Celluloid
     end
 
     def backtrace
-      "#{self.class} backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here."
+      ["#{self.class} backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here."]
     end
   end
 end


### PR DESCRIPTION
https://github.com/celluloid/celluloid/issues/428

Proposed fix, so that `Celluloid::stack_dump` will work again.
