### PR TITLE
Internal pool fixes

### DIFF
--- a/lib/celluloid/internal_pool.rb
+++ b/lib/celluloid/internal_pool.rb
@@ -7,7 +7,10 @@ module Celluloid
 
     def initialize
       @mutex = Mutex.new
-      @threads = []
+      @idle_threads = []
+      @all_threads  = []
+      @busy_size = 0
+      @idle_size = 0
 
       # TODO: should really adjust this based on usage
       @max_idle = 16
@@ -15,17 +18,15 @@ module Celluloid
     end
 
     def busy_size
-      @threads.select(&:busy).size
+      @busy_size
     end
 
     def idle_size
-      @threads.reject(&:busy).size
+      @idle_size
     end
 
     def assert_running
-      unless running?
-        raise Error, "Thread pool is not running"
-      end
+      raise Error, "Thread pool is not running" unless running?
     end
 
     def assert_inactive
@@ -44,17 +45,15 @@ module Celluloid
     end
 
     def active?
-      to_a.any?
+      busy_size + idle_size > 0
     end
 
     def each
-      @threads.each do |thread|
-        yield thread
-      end
+      to_a.each {|thread| yield thread }
     end
 
     def to_a
-      @threads
+      @mutex.synchronize { @all_threads.dup }
     end
 
     # Get a thread from the pool, running the given block
@@ -63,15 +62,16 @@ module Celluloid
         assert_running
 
         begin
-          idle = @threads.reject(&:busy)
-          if idle.empty?
+          if @idle_threads.empty?
             thread = create
           else
-            thread = idle.first
+            thread = @idle_threads.pop
+            @idle_size = @idle_threads.length
           end
         end until thread.status # handle crashed threads
 
         thread.busy = true
+        @busy_size += 1
         thread[:celluloid_queue] << block
         thread
       end
@@ -81,14 +81,45 @@ module Celluloid
     def put(thread)
       @mutex.synchronize do
         thread.busy = false
-        if idle_size >= @max_idle
+        if idle_size + 1 >= @max_idle
           thread[:celluloid_queue] << nil
-          @threads.delete(thread)
+          @busy_size -= 1
+          @all_threads.delete(thread)
         else
+          @idle_threads.push thread
+          @busy_size -= 1
+          @idle_size = @idle_threads.length
           clean_thread_locals(thread)
         end
       end
     end
+
+    def shutdown
+      @mutex.synchronize do
+        finalize
+        @all_threads.each do |thread|
+          thread[:celluloid_queue] << nil
+        end
+        @all_threads.clear
+        @idle_threads.clear
+        @busy_size = 0
+        @idle_size = 0
+      end
+    end
+
+    def kill
+      @mutex.synchronize do
+        finalize
+        @running = false
+
+        @all_threads.shift.kill until @all_threads.empty?
+        @idle_threads.clear
+        @busy_size = 0
+        @idle_size = 0
+      end
+    end
+
+    private
 
     # Create a new thread with an associated queue of procs to run
     def create
@@ -106,7 +137,8 @@ module Celluloid
       end
 
       thread[:celluloid_queue] = queue
-      @threads << thread
+      # @idle_threads << thread
+      @all_threads << thread
       thread
     end
 
@@ -119,26 +151,6 @@ module Celluloid
         thread[key] = nil
       end
     end
-
-    def shutdown
-      @mutex.synchronize do
-        finalize
-        @threads.each do |thread|
-          thread[:celluloid_queue] << nil
-        end
-      end
-    end
-
-    def kill
-      @mutex.synchronize do
-        finalize
-        @running = false
-
-        @threads.shift.kill until @threads.empty?
-      end
-    end
-
-    private
 
     def finalize
       @max_idle = 0


### PR DESCRIPTION
This PR fixes several major problems with InternalPool. See #418 for context.
1. `busy_size` and `idle_size` were previously performing unsynchronized iteration of the threads array. These are now simple scalars that are tracked separately.
2. `to_a` returned the unsynchronized thread array. It now synchronizes a duplication and returns the duplicate unsynchronized.
3. `create` and `clean_thread_locals` are now private.
4. `active?` is now O(1) rather than O(n)
5. `each` uses `to_a` now and operates unsynchronized on a duplicate of the `@all_threads` array, rather than opting for synchronized access to the real array.
6. `get` performs an O(1) pop with no intermediate array, rather than an O(n) array build.

The code is less clean than I'd like, but it preserves all the existing semantics while fixing the outstanding problems.
