### PR TITLE
Fix retrieve the actor from the supervisor properly

### DIFF
--- a/examples/supervisors_and_registry.rb
+++ b/examples/supervisors_and_registry.rb
@@ -34,7 +34,7 @@ puts "Brace yourself for a crash message..."
 # If we call a method that crashes an actor, it will print out a debug message,
 # then restart an actor in a clean state
 begin
-  supervisor.actor.broken_method
+  supervisor.actors.first.broken_method
 rescue NameError
   puts "Uhoh, we crashed the actor..."
 end


### PR DESCRIPTION
The supervisor.actor.broken_method fails to call the broken_method because the supervisor.actor call does not return the actor. Use supervisor.actors.first instead.
