### PR TITLE
Updating pool_manager to fix NameError problem

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -132,7 +132,7 @@ module Celluloid
     end
 
     def respond_to?(method, include_private = false)
-      super || @worker_class.instance_methods.include?(method.to_sym)
+      super || worker_respond_to?(method, include_private)
     end
     
     def method(method)


### PR DESCRIPTION
The pool_manager kept producing NameErrors in calls.rb:33 because it was not forwarding the "method" method call and "respond_to?" method properly to the @worker_class.

Have a look at the issue I created (wrongly) in the guard/listen gem for longer explanation: https://github.com/guard/listen/issues/268
