### PR TITLE
Send :worker_idle signal

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -49,6 +49,10 @@ module Celluloid
         if worker.alive?
           @idle << worker
           @busy.delete worker
+
+          # Broadcast that worker is done processing and
+          # waiting idle
+          signal :worker_idle
         end
       end
     end


### PR DESCRIPTION
I've been playing recently with Celluloid and wanted to use it for a side project. I wanted to build my queue consumer library on Celluloid's `pool` but found it limiting. I wanted to have fixed size pool of workers processing given task with block and wait for idle ones to process another buffered tasks. After analyzing `pool_manager` code it turned out that small modification which is subject of this PR would satisfy my needs.

Here's sample code which uses this feature:

```ruby
require 'celluloid/autostart'
require 'logger'

class Processor
  include Celluloid
  attr_accessor :logger

  def initialize
   @logger = ::Logger.new(STDOUT)
  end

  def process!(i)
    logger.debug("Processing task i=#{i}")
    sleep(10)
    logger.debug("Finished task i=#{i}")
  end
end

class Worker
  include Celluloid

  def run!
    pool = Processor.pool(size: 5)
    100.times do |i|
      pool.wait :worker_idle unless pool.idle_size > 0
      pool.async.process!(i)
    end
  end
end

Worker.new.run!
```

I'm not sure if calling `pool.idle_size` is thread safe and quite don't know how to test my addition.

@tarcieri what do you think? Does what I'm doing make sense? Maybe I can achieve what I want to do with other Celluloid primitives? (pool + condvar?)