### PR TITLE
Timeout extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'coveralls', require: false
 gem 'pry'
 
 gem 'timers', github: 'celluloid/timers'
+gem 'timeout-extensions', github: 'celluloid/timeout'
 
 if RUBY_PLATFORM =~ /darwin/
   gem 'rb-fsevent', '~> 0.9.1'

--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_path = 'lib'
 
   gem.add_runtime_dependency 'timers', '~> 4.0.0'
+  gem.add_runtime_dependency 'timeout-extensions'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 2.14.1'

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -3,6 +3,8 @@ require 'thread'
 require 'timeout'
 require 'set'
 
+require 'timeout/extensions'
+
 module Celluloid
   # Expose all instance methods as singleton methods
   extend self

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -403,12 +403,13 @@ module Celluloid
   end
 
   # Timeout on task suspension 
-  def timeout(duration)
+  # The second argument is the exception that will be raised on timeouts
+  def timeout(duration, klass = Task::TimeoutError)
     bt = caller
     task = Task.current
     timers = Thread.current[:celluloid_actor].timers
     timer = timers.after(duration) do
-      exception = Task::TimeoutError.new("execution expired")
+      exception = klass.new("execution expired")
       exception.set_backtrace bt
       task.resume exception
     end

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -398,6 +398,7 @@ module Celluloid
   # Sleep letting the actor continue processing messages
   def sleep(interval)
     actor = Thread.current[:celluloid_actor]
+    return Kernel.sleep(interval) unless actor
     sleeper = Sleeper.new(actor.timers, interval)
     Celluloid.suspend(:sleeping, sleeper)
   end

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -411,6 +411,7 @@ module Celluloid
     timers = Thread.current[:celluloid_actor].timers
     timer = timers.after(duration) do
       exception = klass.new("execution expired")
+      exception.extend(Celluloid::ResumableError) if not exception.is_a?(Celluloid::ResumableError)
       exception.set_backtrace bt
       task.resume exception
     end

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -246,26 +246,12 @@ module Celluloid
     end
     private :timeout
 
-    class Sleeper
-      def initialize(timers, interval)
-        @timers = timers
-        @interval = interval
-      end
-
-      def before_suspend(task)
-        @timers.after(@interval) { task.resume }
-      end
-
-      def wait
-        Kernel.sleep(@interval)
-      end
-    end
 
     # Sleep for the given amount of time
     def sleep(interval)
-      sleeper = Sleeper.new(@timers, interval)
-      Celluloid.suspend(:sleeping, sleeper)
+      Celluloid::sleep(interval)
     end
+    private :sleep
 
     # Handle standard low-priority messages
     def handle_message(message)

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -242,17 +242,9 @@ module Celluloid
     end
 
     def timeout(duration)
-      bt = caller
-      task = Task.current
-      timer = @timers.after(duration) do
-        exception = Task::TimeoutError.new("execution expired")
-        exception.set_backtrace bt
-        task.resume exception
-      end
-      yield
-    ensure
-      timer.cancel if timer
+      Celluloid::timeout(duration) { yield }
     end
+    private :timeout
 
     class Sleeper
       def initialize(timers, interval)

--- a/lib/celluloid/internal_pool.rb
+++ b/lib/celluloid/internal_pool.rb
@@ -124,6 +124,8 @@ module Celluloid
     def create
       queue = Queue.new
       thread = Thread.new do
+        Thread.current.timeout_handler = Celluloid.method(:timeout).to_proc
+        Thread.current.sleep_handler = Celluloid.method(:sleep).to_proc
         while proc = queue.pop
           begin
             proc.call

--- a/lib/celluloid/rspec/actor_examples.rb
+++ b/lib/celluloid/rspec/actor_examples.rb
@@ -1028,7 +1028,7 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
         end
 
         def ask_name_with_timeout(other, duration)
-          timeout(duration) { other.name }
+          Timeout::timeout(duration) { other.name }
         end
       end
     end

--- a/lib/celluloid/tasks.rb
+++ b/lib/celluloid/tasks.rb
@@ -6,13 +6,13 @@ module Celluloid
   class DeadTaskError < Celluloid::Error; end
 
   # Errors which should be resumed automatically
-  class ResumableError < Celluloid::Error; end
+  module ResumableError ; end
 
   # Tasks are interruptable/resumable execution contexts used to run methods
   class Task
-    class TerminatedError < ResumableError; end # kill a running task after terminate
+    class TerminatedError < Celluloid::Error; include ResumableError ;end # kill a running task after terminate
 
-    class TimeoutError < ResumableError; end # kill a running task after timeout
+    class TimeoutError < Celluloid::Error; include ResumableError ;end # kill a running task after timeout
 
     # Obtain the current task
     def self.current


### PR DESCRIPTION
Continuation of what's going on [here](https://github.com/celluloid/timeout/pull/1#issuecomment-70564139). This is how I envisioned integrating the extensions into celluloid. Main changes are a few Exceptions, method signatures and the fact that the main timeout and sleep logic is directly inside the Celluloid module, instead of inside the actor.

Main discussion topics:

1. I think that the Actor should drop the timeout and sleep instance methods. I mean, they should be using timeout and sleep directly, which will revert to the handlers inside its thread. This will not be a breaking change for the ones who have been using timeout and sleep inside the actor scope as if they were a private method, but it would break such usages as `Thread.current[:celluloid_actor].timeout(duration)...:` 
2. I think that one should drop Celluloid::Task::TimeoutError in favour of Timeout::Error. I mean, one should use the same exceptions as other potential libraries expect (Net::SSH, Net::HTTP, etc, they all work with it). I think one did it because of the ResumableError class, but since this has become a module, one could "extend" the Timeout::Error instance before resuming the task (see how this was solved under Celluloid.timeout).
3. A somewhat elephant in the room is Celluloid.sleep argument handling. I couldn't really mimic the Kernel.sleep method signature, as you can call sleep without arguments. The question here is, should one allow celluloid actors to sleep forever? Does the timers gem support this feature? Do you think this is a relevant use-case? I think one should at least throw a relevant exception for the case in which no argument is passed to a sleep evaluated inside an actor.

