### PR TITLE
Fix silently failing terminate() errors

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -136,12 +136,23 @@ module Celluloid
     end
 
     def respond_to?(meth, include_private = false)
-      fail NotImplementedError if include_private
       # NOTE: use method() here since this class
       # shouldn't be used directly, and method() is less
       # likely to be "reimplemented" inconsistently
       # with other Object.*method* methods.
-      method(meth)
+
+      found = method(meth)
+      if include_private
+        found ? true : false
+      else
+        if found.is_a?(UnboundMethod)
+          found.owner.public_instance_methods.include?(meth) ||
+            found.owner.protected_instance_methods.include?(meth)
+        else
+          found.receiver.public_methods.include?(meth) ||
+            found.receiver.protected_methods.include?(meth)
+        end
+      end
     rescue NameError
       false
     end

--- a/spec/celluloid/pool_manager_spec.rb
+++ b/spec/celluloid/pool_manager_spec.rb
@@ -33,6 +33,11 @@ describe "Celluloid.pool", actor_system: :global do
 
   subject { MyWorker.pool }
 
+  let(:crashes) { [] }
+
+  before { Celluloid::Logger.stub(:crash) { |*args| crashes << args } }
+  after { fail "Unexpected crashes: #{crashes.inspect}" unless crashes.empty? }
+
   it "processes work units synchronously" do
     subject.process.should be :done
   end
@@ -44,6 +49,7 @@ describe "Celluloid.pool", actor_system: :global do
   end
 
   it "handles crashes" do
+    Celluloid::Logger.stub(:crash)
     expect { subject.crash }.to raise_error(ExampleError)
     subject.process.should be :done
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,4 +41,7 @@ RSpec.configure do |config|
     end
   end
 
+  %w(rspec-expectations rspec-core rspec-mocks).each do |gem|
+    config.backtrace_clean_patterns << /gems\/#{gem}-\d+\.\d+\.\d+/
+  end
 end


### PR DESCRIPTION
Cell#shutdown failed while checking for a finalizer, because
PoolManager#respond_to?(meth, true) was not fully implemented.