### PR TITLE
fix issue #500: do not hold mailbox lock while calling reactor wakeup routine

### DIFF
--- a/lib/celluloid/evented_mailbox.rb
+++ b/lib/celluloid/evented_mailbox.rb
@@ -24,14 +24,15 @@ module Celluloid
         else
           @messages << message
         end
-
+      ensure
+        @mutex.unlock rescue nil
+      end
+      begin
         current_actor = Thread.current[:celluloid_actor]
         @reactor.wakeup unless current_actor && current_actor.mailbox == self
       rescue IOError
         Logger.crash "reactor crashed", $!
         dead_letter(message)
-      ensure
-        @mutex.unlock rescue nil
       end
       nil
     end


### PR DESCRIPTION
A more elegant solution to avoid retaking the mutex