### PR TITLE
pin the version of timers

### DIFF
--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.files        = Dir['README.md', 'lib/**/*', 'spec/support/**/*']
   gem.require_path = 'lib'
 
-  gem.add_runtime_dependency 'timers', '>= 1.0.0'
+  gem.add_runtime_dependency 'timers', '~> 2'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
 Fixes the incompatibility with versions of timers > 2.

In particular: ```/var/lib/jenkins/.rvm/gems/ruby-1.9.3-p484@global/gems/celluloid-0.14.1/lib/celluloid/receivers.rb:9:in `initialize': undefined method `new' for Timers:Module (NoMethodError)```