### PR TITLE
refactor out supervise* methods a bit + add tests

### DIFF
--- a/lib/celluloid/rspec/actor_examples.rb
+++ b/lib/celluloid/rspec/actor_examples.rb
@@ -830,7 +830,7 @@ RSpec.shared_examples "Celluloid::Actor examples" do |included_module, task_klas
       expect(Time.now - started_at).to be_within(Celluloid::TIMER_QUANTUM).of interval
     end
 
-    it "schedules timers which fire in the future" do
+    it "schedules timers which fire in the future", flaky: true do
       actor = @klass.new
 
       interval = Celluloid::TIMER_QUANTUM * 10

--- a/lib/celluloid/supervision_helper.rb
+++ b/lib/celluloid/supervision_helper.rb
@@ -1,0 +1,21 @@
+module Celluloid
+  module SupervisionHelper
+    def supervise(klass, *args, &block)
+      supervise_with_options(klass, prepare_options(args, :block => block))
+    end
+
+    def supervise_as(name, klass, *args, &block)
+      supervise_with_options(klass, prepare_options(args, :block => block, :as => name))
+    end
+
+    private
+
+    def supervise_with_options(klass, options)
+      fail NotImplementedError
+    end
+
+    def prepare_options(args, options = {})
+      ( ( args.length == 1 and args[0].is_a? Hash ) ? args[0] : { :args => args } ).merge( options )
+    end
+  end
+end

--- a/lib/celluloid/supervisor.rb
+++ b/lib/celluloid/supervisor.rb
@@ -1,3 +1,5 @@
+require 'celluloid/supervision_helper'
+
 module Celluloid
   # Supervisors are actors that watch over other actors and restart them if
   # they crash
@@ -6,16 +8,12 @@ module Celluloid
       # Define the root of the supervision tree
       attr_accessor :root
 
-      def supervise(klass, *args, &block)
-        SupervisionGroup.new do |group|
-          group.supervise klass, *args, &block
-        end
-      end
+      include SupervisionHelper
 
-      def supervise_as(name, klass, *args, &block)
-        SupervisionGroup.new do |group|
-          group.supervise_as name, klass, *args, &block
-        end
+      private
+
+      def supervise_with_options(klass, options)
+        SupervisionGroup.new { |group| group.add(klass, options) }
       end
     end
   end

--- a/spec/celluloid/supervision_group_spec.rb
+++ b/spec/celluloid/supervision_group_spec.rb
@@ -34,10 +34,58 @@ RSpec.describe Celluloid::SupervisionGroup, actor_system: :global do
     expect(Celluloid::Actor[:example]).to be_nil
   end
 
-  context "args" do
-    it "passes them"  do
+  describe ".supervise" do
+    it "passes non-hash argument"  do
       group_klass = Class.new(Celluloid::SupervisionGroup) do
-        supervise MyActor, as: :example, args: [:foo, :bar]
+        supervisor = supervise MyActor, as: :example, args: [:foo, :bar]
+      end
+      group = group_klass.run!
+      sleep 0.01
+      expect(group.actors.first.args).to eq([:foo, :bar])
+    end
+
+    it "passes multiple non-hash arguments" do
+      supervisor = nil
+      group_klass = Class.new(Celluloid::SupervisionGroup) do
+        supervise MyActor, :foo, :bar
+      end
+      group = group_klass.run!
+      sleep 0.01
+      expect(group.actors.first.args).to eq([:foo, :bar])
+    end
+
+    it "supports lazy evaluation" do
+      group_klass = Class.new(Celluloid::SupervisionGroup) do
+        supervise MyActor, args: ->{ :lazy }
+      end
+      group = group_klass.run!
+      sleep 0.01
+      expect(group.actors.first.args).to eq([:lazy])
+    end
+
+    it "supports hash with celluloid options" do
+      group_klass = Class.new(Celluloid::SupervisionGroup) do
+        supervise MyActor, as: :example, args: :foo
+      end
+      group = group_klass.run!
+      sleep 0.01
+      expect(Celluloid::Actor[:example].args).to eq([:foo])
+    end
+  end
+
+  describe ".supervise_as" do
+    it "passes non-hash argument" do
+      group_klass = Class.new(Celluloid::SupervisionGroup) do
+        supervise_as :example, MyActor, :foo
+      end
+      group_klass.run!
+      sleep 0.01
+      expect(Celluloid::Actor[:example].args).to eq([:foo])
+    end
+
+    it "passes multiple non-hash arguments" do
+      group_klass = Class.new(Celluloid::SupervisionGroup) do
+        supervise_as :example, MyActor, :foo, :bar
       end
       group_klass.run!
       sleep 0.01
@@ -46,15 +94,24 @@ RSpec.describe Celluloid::SupervisionGroup, actor_system: :global do
 
     it "supports lazy evaluation" do
       group_klass = Class.new(Celluloid::SupervisionGroup) do
-        supervise MyActor, as: :example, args: ->{ :lazy }
+        supervise_as :example, MyActor, args: ->{ :lazy }
       end
       group_klass.run!
       sleep 0.01
       expect(Celluloid::Actor[:example].args).to eq([:lazy])
     end
+
+    it "supports hash with celluloid options" do
+      group_klass = Class.new(Celluloid::SupervisionGroup) do
+        supervise_as :example, MyActor, args: :foo
+      end
+      group = group_klass.run!
+      sleep 0.01
+      expect(Celluloid::Actor[:example].args).to eq([:foo])
+    end
   end
 
-  context "pool" do
+  context ".pool" do
     before :all do
       class MyActor
         attr_reader :args

--- a/spec/celluloid/supervisor_spec.rb
+++ b/spec/celluloid/supervisor_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe Celluloid::Supervisor, actor_system: :global do
     include Celluloid
     attr_reader :state
 
-    def initialize(state)
+    def initialize(state, &block)
       @state = state
+      block.call if block_given?
     end
 
     def crack_the_whip
@@ -97,5 +98,25 @@ RSpec.describe Celluloid::Supervisor, actor_system: :global do
     subordinate.terminate
 
     expect(supervisor.actors).to be_empty
+  end
+
+  describe ".supervise" do
+    it "calls the given block" do
+      value = 1
+      Celluloid::Supervisor.supervise(Subordinate, :idle) do
+        value += 1
+      end
+      expect(value).to eq(2)
+    end
+  end
+
+  describe ".supervise_as" do
+    it "calls the given block" do
+      value = 1
+      Celluloid::Supervisor.supervise_as(:subordinate, Subordinate, :idle) do
+        value += 1
+      end
+      expect(value).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
Refactor out `supervise` and `supervise_as` methods to external module to avoid duplication + add more tests for testing parameter handling (related to #506, #505, #504, #503).