### PR TITLE
[backport] shutdown quickly when inside fork() [fix #468]

### DIFF
--- a/lib/celluloid/internal_pool.rb
+++ b/lib/celluloid/internal_pool.rb
@@ -6,6 +6,8 @@ module Celluloid
     attr_accessor :max_idle
 
     def initialize
+      @pid = $$
+
       @mutex = Mutex.new
       @idle_threads = []
       @all_threads  = []
@@ -52,6 +54,7 @@ module Celluloid
     end
 
     def to_a
+      return [] if forked?
       @mutex.synchronize { @all_threads.dup }
     end
 
@@ -153,6 +156,10 @@ module Celluloid
 
     def finalize
       @max_idle = 0
+    end
+
+    def forked?
+      @pid != $$
     end
   end
 end

--- a/spec/celluloid/internal_pool_spec.rb
+++ b/spec/celluloid/internal_pool_spec.rb
@@ -69,4 +69,18 @@ RSpec.describe Celluloid::InternalPool do
 
     expect(subject.to_a.size).to eq(0)
   end
+
+  context "with a running thread" do
+    let(:queue) { Queue.new }
+
+    before { subject.get { queue.pop } }
+    after { queue << nil }
+
+    it "does not return dead threads inside fork()" do
+      # Hack: use child process exit code to store number of threads/actors
+      pid = fork { exit(subject.to_a.size) }
+      child_actor_count = Process.wait2(pid).last.exitstatus
+      expect(child_actor_count).to be_zero
+    end
+  end
 end


### PR DESCRIPTION
Backport of `#513` on to `0-16-stable`