### PR TITLE
Silence $CELLULOID_DEBUG-related warnings

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -3,6 +3,8 @@ require 'thread'
 require 'timeout'
 require 'set'
 
+$CELLULOID_DEBUG = false
+
 module Celluloid
   # Expose all instance methods as singleton methods
   extend self


### PR DESCRIPTION
For some reason explicitly initializing a global is causing test failures via spooky action at a distance. Kill me now.

@schmurfy this is your code that's breaking. Any ideas?