### PR TITLE
Isolate `dead?` code in own branch.

### DIFF
--- a/lib/celluloid/proxies/actor_proxy.rb
+++ b/lib/celluloid/proxies/actor_proxy.rb
@@ -22,6 +22,10 @@ module Celluloid
       @mailbox.alive?
     end
 
+    def dead?
+      !alive?
+    end
+
     # Terminate the associated actor
     def terminate
       terminate!

--- a/lib/celluloid/proxies/cell_proxy.rb
+++ b/lib/celluloid/proxies/cell_proxy.rb
@@ -51,6 +51,10 @@ module Celluloid
       @actor_proxy.alive?
     end
 
+    def dead?
+      @actor_proxy.dead?
+    end
+
     def thread
       @actor_proxy.thread
     end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -395,6 +395,19 @@ shared_examples "Celluloid::Actor examples" do |included_module, task_klass|
       actor.should_not be_alive
     end
 
+    it "is not dead when it's alive" do
+      actor = actor_class.new 'Bill Murray'
+      actor.should be_alive
+      actor.should_not be_dead
+    end
+
+    it "is dead when it's not alive" do
+      actor = actor_class.new 'Bill Murray'
+      actor.terminate
+      actor.should_not be_alive
+      actor.should be_dead
+    end
+
     it "raises DeadActorError if called after terminated" do
       actor = actor_class.new "Arnold Schwarzenegger"
       actor.terminate


### PR DESCRIPTION
Closes #350 once conflicts are worked out.