### PR TITLE
Publish module method, and pub/sub example.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ HEAD
 * Make "Terminating task" log messages debug-level events
 * Fix $CELLULOID_TEST warnings
 * Added `.dead?` method on actors, as opposite of `.alive?`
+* Added class/module method to access `publish` outside actors.
 
 0.16.0 (2014-09-04)
 -------------------

--- a/examples/pubsub.rb
+++ b/examples/pubsub.rb
@@ -1,0 +1,36 @@
+require 'celluloid/autostart'
+
+class Publisher 
+  include Celluloid
+  include Celluloid::Notifications
+
+  def initialize
+    now = Time.now.to_f
+    sleep now.ceil - now + 0.001
+    9.times {
+      publish 'example_write_by_instance_method', Time.now
+    }
+  end
+end
+
+class Subscriber
+  include Celluloid
+  include Celluloid::Notifications
+  include Celluloid::Logger
+
+  def initialize
+    info "Subscribing to topics."
+    subscribe 'example_write_by_instance_method', :new_message
+    subscribe 'example_write_by_class_method', :new_message
+  end
+
+  def new_message(topic,data)
+    info "#{topic}: #{data}"
+  end
+end
+
+sub = Subscriber.new
+
+Celluloid::Notifications.publish "example_write_by_class_method", Time.now
+
+pub = Publisher.new

--- a/lib/celluloid/notifications.rb
+++ b/lib/celluloid/notifications.rb
@@ -82,7 +82,7 @@ module Celluloid
     end
   end
 
-  def self.publish *args
-    Notifications.publish *args
+  def self.publish(*args)
+    Notifications.publish(*args)
   end
 end

--- a/lib/celluloid/notifications.rb
+++ b/lib/celluloid/notifications.rb
@@ -7,6 +7,7 @@ module Celluloid
     def publish(pattern, *args)
       Celluloid::Notifications.notifier.publish(pattern, *args)
     end
+    module_function :publish
 
     def subscribe(pattern, method)
       Celluloid::Notifications.notifier.subscribe(Actor.current, pattern, method)

--- a/lib/celluloid/notifications.rb
+++ b/lib/celluloid/notifications.rb
@@ -81,4 +81,8 @@ module Celluloid
       end
     end
   end
+
+  def self.publish *args
+    Notifications.publish *args
+  end
 end

--- a/spec/celluloid/probe_spec.rb
+++ b/spec/celluloid/probe_spec.rb
@@ -34,6 +34,9 @@ class TestProbeClient
   end
 end
 
+puts "CELLULOID_MONITORING: #{$CELLULOID_MONITORING}"
+
+
 RSpec.describe "Probe", actor_system: :global do
   describe 'on boot' do
     it 'should capture system actor spawn', flaky: true do
@@ -44,7 +47,6 @@ RSpec.describe "Probe", actor_system: :global do
         :default_incident_reporter => nil,
         :notifications_fanout      => nil
       }
-      sleep 0.9
       # wait for the events we seek
       Timeout.timeout(5) do
         loop do

--- a/spec/celluloid/probe_spec.rb
+++ b/spec/celluloid/probe_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe "Probe", actor_system: :global do
         :default_incident_reporter => nil,
         :notifications_fanout      => nil
       }
+      sleep 0.9
       # wait for the events we seek
       Timeout.timeout(5) do
         loop do
           client.wait
-          sleep 0.9
           while ev = client.buffer.shift
             if ev[0] == 'celluloid.events.actor_created'
               create_events << ev

--- a/spec/celluloid/probe_spec.rb
+++ b/spec/celluloid/probe_spec.rb
@@ -36,7 +36,7 @@ end
 
 RSpec.describe "Probe", actor_system: :global do
   describe 'on boot' do
-    it 'should capture system actor spawn' do
+    it 'should capture system actor spawn', flaky: true do
       client = TestProbeClient.new
       Celluloid::Probe.run
       create_events = []
@@ -48,6 +48,7 @@ RSpec.describe "Probe", actor_system: :global do
       Timeout.timeout(5) do
         loop do
           client.wait
+          sleep 0.9
           while ev = client.buffer.shift
             if ev[0] == 'celluloid.events.actor_created'
               create_events << ev


### PR DESCRIPTION
This not only adds support to cover #334, it also brings in an example for the wiki so we don't need to only reference `Reel`