### PR TITLE
Separate testing using fibers vs threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 script: rake ci
+language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
@@ -15,15 +16,13 @@ matrix:
     - rvm: jruby
     - rvm: jruby-head
     - rvm: rbx-2
-  global:
-    - BUNDLE_JOBS=4
 
 notifications:
   irc: "irc.freenode.org#celluloid"
 
 before_install:
   # Only use 1 job until Travis fixes the rbx --jobs issue.
-  - if [ "$TRAVIS_RUBY_VERSION" == "rbx-2" ] ; then export BUNDLE_JOBS=1 ; fi
+  - if [ "$TRAVIS_RUBY_VERSION" == "rbx-2" ] ; then export BUNDLE_JOBS=1 ; else export BUNDLE_JOBS=4; fi
 
 sudo: false
 install: bundle install --retry=3 --without=development

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ script: rake ci
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.4
+  - 2.2.0
   - ruby-head
   - jruby
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - rvm: jruby
     - rvm: jruby-head
     - rvm: rbx-2
+env:
+  - CELLULOID_TASK_CLASS=Celluloid::TaskFiber
+  - CELLULOID_TASK_CLASS=Celluloid::TaskThread
 
 notifications:
   irc: "irc.freenode.org#celluloid"

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -510,7 +510,12 @@ require 'celluloid/legacy' unless defined?(CELLULOID_FUTURE)
 $CELLULOID_MONITORING = false
 
 # Configure default systemwide settings
-Celluloid.task_class = Celluloid::TaskFiber
+Celluloid.task_class = begin
+                         Kernel.const_get(ENV['CELLULOID_TASK_CLASS'])
+                       rescue TypeError
+                         Celluloid::TaskFiber
+                       end
+
 Celluloid.logger     = Logger.new(STDERR)
 Celluloid.shutdown_timeout = 10
 Celluloid.log_actor_crashes = true

--- a/lib/celluloid/rspec/actor_examples.rb
+++ b/lib/celluloid/rspec/actor_examples.rb
@@ -1,9 +1,6 @@
 RSpec.shared_examples "a Celluloid Actor" do |included_module|
-  describe "using Fibers" do
-    include_examples "Celluloid::Actor examples", included_module, Celluloid::TaskFiber
-  end
-  describe "using Threads" do
-    include_examples "Celluloid::Actor examples", included_module, Celluloid::TaskThread
+  describe "using #{Celluloid.task_class}" do
+    include_examples "Celluloid::Actor examples", included_module, Celluloid.task_class
   end
 end
 
@@ -993,7 +990,7 @@ RSpec.shared_examples "Celluloid::Actor examples" do |included_module, task_klas
   end
 
   context :task_class do
-    class ExampleTask < Celluloid::TaskFiber; end
+    class ExampleTask < Celluloid.task_class; end
 
     subject do
       Class.new do

--- a/lib/celluloid/rspec/example_actor_class.rb
+++ b/lib/celluloid/rspec/example_actor_class.rb
@@ -1,3 +1,7 @@
+class ExampleCrash < StandardError
+  attr_accessor :foo
+end
+
 module ExampleActorClass
   def self.create(included_module, task_klass)
     Class.new do

--- a/lib/celluloid/rspec/task_examples.rb
+++ b/lib/celluloid/rspec/task_examples.rb
@@ -9,12 +9,12 @@ class MockActor
   end
 end
 
-RSpec.shared_context "a Celluloid Task" do |task_class|
+RSpec.shared_context "a Celluloid Task" do
   let(:task_type)     { :foobar }
   let(:suspend_state) { :doing_something }
   let(:actor)         { MockActor.new }
 
-  subject { task_class.new(task_type, {}) { Celluloid::Task.suspend(suspend_state) } }
+  subject { Celluloid.task_class.new(task_type, {}) { Celluloid::Task.suspend(suspend_state) } }
 
   before :each do
     Thread.current[:celluloid_actor_system] = Celluloid.actor_system
@@ -39,7 +39,7 @@ RSpec.shared_context "a Celluloid Task" do |task_class|
   end
 
   it "raises exceptions outside" do
-    task = task_class.new(task_type, {}) do
+    task = Celluloid.task_class.new(task_type, {}) do
       raise "failure"
     end
     expect do

--- a/spec/celluloid/actor_system_spec.rb
+++ b/spec/celluloid/actor_system_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Celluloid::ActorSystem do
 
   it "support getting threads" do
     queue = Queue.new
-    thread = subject.get_thread do
+    subject.get_thread do
       expect(Celluloid.actor_system).to eq(subject)
       queue << nil
     end

--- a/spec/celluloid/probe_spec.rb
+++ b/spec/celluloid/probe_spec.rb
@@ -34,9 +34,6 @@ class TestProbeClient
   end
 end
 
-puts "CELLULOID_MONITORING: #{$CELLULOID_MONITORING}"
-
-
 RSpec.describe "Probe", actor_system: :global do
   describe 'on boot' do
     it 'should capture system actor spawn', flaky: true do

--- a/spec/celluloid/supervision_group_spec.rb
+++ b/spec/celluloid/supervision_group_spec.rb
@@ -56,19 +56,22 @@ RSpec.describe Celluloid::SupervisionGroup, actor_system: :global do
 
   context "pool" do
     before :all do
-      class MyActor
+      class MyPoolActor
+        include Celluloid
+
         attr_reader :args
         def initialize *args
           @args = *args
         end
+        def running?; :yep; end
       end
-      class MyGroup
-        pool MyActor, :as => :example_pool, :args => 'foo', :size => 3
+      class MyPoolGroup < Celluloid::SupervisionGroup
+        pool MyPoolActor, :as => :example_pool, :args => 'foo', :size => 3
       end
     end
 
     it "runs applications and passes pool options and actor args" do
-      MyGroup.run!
+      MyPoolGroup.run!
       sleep 0.001 # startup time hax
 
       expect(Celluloid::Actor[:example_pool]).to be_running

--- a/spec/celluloid/tasks/task_fiber_spec.rb
+++ b/spec/celluloid/tasks/task_fiber_spec.rb
@@ -1,3 +1,5 @@
 RSpec.describe Celluloid::TaskFiber, actor_system: :within do
-  it_behaves_like "a Celluloid Task", Celluloid::TaskFiber
+  if Celluloid.task_class == Celluloid::TaskFiber
+    it_behaves_like "a Celluloid Task"
+  end
 end

--- a/spec/celluloid/tasks/task_thread_spec.rb
+++ b/spec/celluloid/tasks/task_thread_spec.rb
@@ -1,3 +1,5 @@
 RSpec.describe Celluloid::TaskThread, actor_system: :within do
-  it_behaves_like "a Celluloid Task", Celluloid::TaskThread
+  if Celluloid.task_class == Celluloid::TaskThread
+    it_behaves_like "a Celluloid Task"
+  end
 end

--- a/spec/celluloid/timer_spec.rb
+++ b/spec/celluloid/timer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Celluloid::Actor do
 
     sleep 5.5
 
-    times = every_actor.times
+    every_actor.times
     trace = every_actor.trace
 
     Celluloid.shutdown


### PR DESCRIPTION
Benefits (development):
- task based tests aren't run twice in dev
- ~~shared examples can now be refactored out~~
- slightly less tests during dev before PRs
- better insights in case of Travis failures
- extra test covered in stack dump

Downside:
- larger travis build matrix (can be selectively reduced as needed)