### PR TITLE
Rework stack dump specs

### DIFF
--- a/lib/celluloid/groups/spawner.rb
+++ b/lib/celluloid/groups/spawner.rb
@@ -39,9 +39,6 @@ module Celluloid
             proc.call
           rescue Exception => ex
             Logger.crash("thread crashed", ex)
-          ensure
-            Thread.current.keys.each { |key| thread[key] = nil }
-            #de purge(Thread.current)
           end
         }
         @mutex.synchronize { @group << thread }

--- a/spec/celluloid/calls_spec.rb
+++ b/spec/celluloid/calls_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Celluloid::SyncCall, actor_system: :global do
     def actual_method; end
 
     def inspect
-      fail "Please don't call me! I'm not ready yet!"
+      fail "Don't call!"
     end
 
     def chained_call_ids
@@ -32,7 +32,7 @@ RSpec.describe Celluloid::SyncCall, actor_system: :global do
       it "should emulate obj.inspect" do
         expect { actor.no_such_method }.to raise_exception(
           NoMethodError,
-          /undefined method `no_such_method' for #\<CallExampleActor:0x[a-f0-9]+ @next=nil>/
+          /undefined method `no_such_method' for #\<CallExampleActor:0x[a-f0-9]+ @celluloid_owner=\(crashed: Don't call!\) @next=nil>/
         )
       end
     end

--- a/spec/celluloid/calls_spec.rb
+++ b/spec/celluloid/calls_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Celluloid::SyncCall, actor_system: :global do
 
     context "when obj raises during inspect" do
       it "should emulate obj.inspect" do
-        expect(actor).to_not receive(:inspect)
         expect { actor.no_such_method }.to raise_exception(
           NoMethodError,
           /undefined method `no_such_method' for #\<CallExampleActor:0x[a-f0-9]+ @next=nil>/

--- a/spec/celluloid/stack_dump_spec.rb
+++ b/spec/celluloid/stack_dump_spec.rb
@@ -1,77 +1,169 @@
 RSpec.describe Celluloid::StackDump do
-  let(:actor_system) do
-    Celluloid::ActorSystem.new
-  end
+  class Wait
+    QUEUE = Queue.new
+    WAITERS = Queue.new
+    ACTORS = Queue.new
 
-  flaky = Celluloid.group_class != Celluloid::Group::Spawner
+    def self.forever
+      WAITERS << Thread.current
+      QUEUE.pop
+    end
 
-  subject do
-    actor_system.stack_dump
+    def self.no_longer
+      Wait::ACTORS.pop.terminate until Wait::ACTORS.empty?
+
+      loop do
+        break if WAITERS.empty?
+        QUEUE << nil
+        nicely_end_thread(WAITERS.pop)
+      end
+    end
+
+    def self.nicely_end_thread(th)
+      return if jruby_fiber?(th)
+
+      status = th.status
+      case status
+      when nil
+      when false
+      when "dead"
+      when "sleep", "run"
+        th.kill
+        th.join(2) || STDERR.puts("Thread join timed out...")
+      else
+        STDERR.puts "unknown status: #{th.status.inspect}"
+      end
+    end
+
+    def self.jruby_fiber?(th)
+      defined?(JRUBY_VERSION) && /Fiber/ =~ th.to_java.getNativeThread.get_name
+    end
   end
 
   class BlockingActor
     include Celluloid
 
+    def initialize(threads)
+      @threads = threads
+    end
+
     def blocking
-      Kernel.sleep
+      Wait::ACTORS << Thread.current
+      @threads << Thread.current
+      Wait.forever
     end
   end
 
-  threadz = 0
+  def create_async_blocking_actor(task_klass)
+    actor_klass = Class.new(BlockingActor) do
+      task_class task_klass
+    end
+
+    actor = actor_system.within do
+      actor_klass.new(threads)
+    end
+
+    actor.async.blocking
+  end
+
+  def create_thread_with_role(threads, role)
+    resume = Queue.new
+    thread = actor_system.get_thread do
+      resume.pop # to avoid race for 'thread' variable
+      thread.role = role
+      threads << thread
+      Wait.forever
+    end
+    resume << nil # to avoid race for 'thread' variable
+    thread
+  end
+
+
+  subject { actor_system.stack_dump }
+
+  let(:actor_system) { Celluloid::ActorSystem.new }
+
+  let(:threads) { Queue.new }
 
   before(:each) do
-    threadz = 0
+    items = 0
 
-    tasks = [Celluloid::Task::Fibered, Celluloid::Task::Threaded]
-    tasks.each do |task_klass|
-      actor_klass = Class.new(BlockingActor) do
-        task_class task_klass
-      end
-      actor = actor_system.within do
-        actor_klass.new
-      end
-      actor.async.blocking
+    [Celluloid::Task::Fibered, Celluloid::Task::Threaded].each do |task_klass|
+      create_async_blocking_actor(task_klass)
+      items += 1
     end
-    threadz += tasks.length
 
-    sleep 0.01 # to allow group to end up with 1 idle thread
+    @active_thread = create_thread_with_role(threads, :other_thing)
+    items += 1
 
-    @active_thread = actor_system.get_thread do
-      sleep
+    @idle_thread = create_thread_with_role(threads, :idle_thing)
+    items += 1
+
+    # Wait for each thread to add itself to the queue
+    tmp = Queue.new
+    items.times do
+      th = threads.pop
+      tmp << th
     end
-    threadz += 1
-    @active_thread.role = :other_thing
 
-    sleep 0.01 # to allow group to end up with 1 idle thread
+    expect(threads).to be_empty
 
-    @idle_thread = actor_system.get_thread do
-    end
-    threadz += 1
+    # put threads back into the queue for killing
+    threads << tmp.pop until tmp.empty?
+  end
 
-    sleep 0.01 # to allow group to end up with 1 idle thread
+  after do
+    Wait.no_longer
+    actor_system.shutdown
   end
 
   describe '#actors' do
     it 'should include all actors' do
-      expect(subject.actors.size).to eq(actor_system.running.size)
+      expect(subject.actors.size).to eq(2)
     end
   end
 
   describe '#threads' do
-    it 'should hold all threads, not only actors', flaky: flaky do
-      expect(subject.threads.size).to eq(threadz)
+    # TODO: this spec should use mocks because it's non-deterministict
+    it 'should include threads that are not actors' do
+      # NOTE: Pool#each doesn't guarantee to contain the newly started thread
+      # because the actor's methods (which create and store the thread handle)
+      # are started asynchronously.
+      #
+      # The mutexes in InternalPool especially can cause additional delay -
+      # causing Pool#get to wait for IPool#each to free the mutex before the
+      # new thread can be stored.
+      #
+      # And, StackDump#threads is cached, so we have to reconstruct the
+      # StackDump until it matches reality.
+      #
+      # Also, the actual number of threads and how InternalPool juggles them is
+      # non deterministic to begin with:
+      #
+      # 2 actors
+      #   -> *0-1 task threads
+      #
+      # *1 idle thread
+      # *1 active thread
+      #
+      # Together: 3-4 threads
+
+      # Pool somehow doesn't create extra tasks
+      # 5 is on JRuby-head
+      expected = (Celluloid.group_class == Celluloid::Group::Pool) ? [3,4] : [4,5,6]
+      expect(expected).to include(subject.threads.size)
     end
 
-    it 'should include idle threads', flaky: flaky do
+    it 'should include idle threads' do
       expect(subject.threads.map(&:thread_id)).to include(@idle_thread.object_id)
     end
 
-    it 'should include threads checked out of the group for roles other than :actor', flaky: flaky do
+    it 'should include threads checked out of the group for roles other than :actor' do
       expect(subject.threads.map(&:thread_id)).to include(@active_thread.object_id)
     end
 
-    it 'should have the correct roles', flaky: flaky do
-      expect(subject.threads.map(&:role)).to include(nil, :other_thing, :task)
+    it 'should have the correct roles' do
+      expect(subject.threads.map(&:role)).to include(:idle_thing, :other_thing)
     end
   end
 end

--- a/spec/support/shared_examples_for_group.rb
+++ b/spec/support/shared_examples_for_group.rb
@@ -100,8 +100,11 @@ RSpec.shared_examples "a Celluloid Group" do
       end
     end
 
-    it "cleans thread locals from old threads" do
-      expect(@thread[:foo]).to be_nil
+    # Cleaning not necessary for Spawner
+    unless Celluloid.group_class == Celluloid::Group::Spawner
+      it "cleans thread locals from old threads" do
+        expect(@thread[:foo]).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
- no longer flaky (except because of bugs in Pool and unrelated races occurring on JRuby)
- includes comments about counting threads (and why it makes little sense)
- overall it should be reworked, but other stuff comes first (test framework improvements, Pool fixes, Thread API, shutdown logic, etc.)