### PR TITLE
remove dependency on supervisors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,6 @@ gem 'coveralls', require: false
 
 gem 'timers', github: 'celluloid/timers'
 
-# keep these gems in the bundle for now, until the world realizes they are gems ( outside core )
-#gem 'celluloid-supervision', github: 'celluloid/celluloid-supervision', branch: "master"
-gem 'celluloid-pool', github: 'celluloid/celluloid-pool', branch: "master"
-gem 'celluloid-fsm', github: 'celluloid/celluloid-fsm', branch: "master"
-gem 'celluloid-extras', github: 'celluloid/celluloid-extras', branch: "master"
-
 gemspec development_group: :gem_build_tools
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'coveralls', require: false
 gem 'timers', github: 'celluloid/timers'
 
 # keep these gems in the bundle for now, until the world realizes they are gems ( outside core )
-gem 'celluloid-supervision', github: 'celluloid/celluloid-supervision', branch: "master"
+#gem 'celluloid-supervision', github: 'celluloid/celluloid-supervision', branch: "master"
 gem 'celluloid-pool', github: 'celluloid/celluloid-pool', branch: "master"
 gem 'celluloid-fsm', github: 'celluloid/celluloid-fsm', branch: "master"
 gem 'celluloid-extras', github: 'celluloid/celluloid-extras', branch: "master"

--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.require_path = 'lib'
 
   gem.add_runtime_dependency 'timers', '~> 4.0.0'
-  gem.add_runtime_dependency 'celluloid-supervision'
   gem.add_runtime_dependency 'celluloid-pool'
   gem.add_runtime_dependency 'celluloid-fsm'
 

--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |gem|
   gem.require_path = 'lib'
 
   gem.add_runtime_dependency 'timers', '~> 4.0.0'
-  gem.add_runtime_dependency 'celluloid-pool'
-  gem.add_runtime_dependency 'celluloid-fsm'
 
   gem.add_development_dependency 'bundler'
 end

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -464,8 +464,6 @@ require 'celluloid/future'
 
 require 'celluloid/actor_system'
 
-# TODO: Remove unneeded gem requirements once the gems are well known.
-require 'celluloid/supervision'
 require 'celluloid/pool'
 require 'celluloid/fsm'
 

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -464,9 +464,6 @@ require 'celluloid/future'
 
 require 'celluloid/actor_system'
 
-require 'celluloid/pool'
-require 'celluloid/fsm'
-
 require 'celluloid/notifications'
 require 'celluloid/logging'
 

--- a/lib/celluloid/logging/incident_reporter.rb
+++ b/lib/celluloid/logging/incident_reporter.rb
@@ -12,6 +12,15 @@ module Celluloid
       end
     end
 
+    def self.start_as_service(name)
+      klass = self
+      if klass.respond_to?(:supervise_as)
+        klass.supervise_as(name, STDERR)
+      else
+        Actor[name] = klass.new(STDERR)
+      end
+    end
+
     def initialize(*args)
       subscribe(/log\.incident/, :report)
       @logger = ::Logger.new(*args)

--- a/lib/celluloid/notifications.rb
+++ b/lib/celluloid/notifications.rb
@@ -25,6 +25,15 @@ module Celluloid
       include Celluloid
       trap_exit :prune
 
+      def self.start_as_service(name)
+        klass = self
+        if klass.respond_to?(:supervise_as)
+          klass.supervise_as(name)
+        else
+          Actor[name] = klass.new
+        end
+      end
+
       def initialize
         @subscribers = []
         @listeners_for = {}

--- a/spec/celluloid/actor_system_spec.rb
+++ b/spec/celluloid/actor_system_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Celluloid::ActorSystem do
     expect(subject.registered).to be_empty
 
     subject.within do
-      TestActor.supervise_as :test
+      subject.registry[:test] = TestActor.new
     end
 
     expect(subject.registered).to eq([:test])


### PR DESCRIPTION
@digitalextremist - this removes Celluloid's dependency on supervisors (Fanout and IncidentReporter will only be supervised if supervisors are included/available).

Still, supervisors will have to be adapted I guess.