### PR TITLE
fix flaky mailbox spec (fix #588)

### DIFF
--- a/spec/support/shared_examples_for_mailbox.rb
+++ b/spec/support/shared_examples_for_mailbox.rb
@@ -43,9 +43,8 @@ RSpec.shared_examples "a Celluloid Mailbox" do
       subject.receive(interval) { false }
     end.to raise_exception(Celluloid::TimeoutError)
 
-    # Travis got 0.16 which is outside 0.05 of 0.1, so let's use (0.05 * 2)
-    error_margin = Nenv.ci? ? 0.08 : CelluloidSpecs::TIMER_QUANTUM
-    expect(Time.now - started_at).to be_within(error_margin).of interval
+    # Just check to make sure it didn't return earlier
+    expect(Time.now - started_at).to be >= interval
   end
 
   it "has a size" do


### PR DESCRIPTION
Just check to make sure the timeout is honored, but not necessarily accurate.