### PR TITLE
fix mocking specs (see #595)

### DIFF
--- a/spec/celluloid/actor_spec.rb
+++ b/spec/celluloid/actor_spec.rb
@@ -368,20 +368,22 @@ RSpec.describe Celluloid, actor_system: :global do
       expect(actor.name).to eq "Spiderman"
     end
 
-    xit "allows mocking raises" do
-      expect(actor).to receive(:foo).and_raise ArgumentError
-      expect { actor.foo }.to raise_error(ArgumentError)
+    it "allows mocking raises" do
+      expect(actor).to receive(:greet).and_raise ArgumentError
+      expect { actor.greet }.to raise_error(ArgumentError)
       expect(actor).to be_alive
     end
 
-    xit "allows mocking async calls via the async proxy" do
-      expect(actor.async).to receive(:foo).once
-      actor.async.foo
+    it "allows mocking async calls via the async proxy" do
+      pending "Fails due to RSpec's new expectation verification"
+      fail "TODO: may never work in newer versions of RSpec (no method on Proxy::Async)"
+      expect(actor.async).to receive(:greet).once
+      actor.async.greet
     end
 
     it "allows mocking async calls via #async send" do
-      expect(actor).to receive(:async).once.with(:foo)
-      actor.async :foo
+      expect(actor).to receive(:async).once.with(:greet)
+      actor.async :greet
     end
   end
 


### PR DESCRIPTION
Fix as much of the mocking specs as possible.

(One spec fails RSpec verification of the method on Proxy::Async)