### PR TITLE
Logical && and || operators for simple Boolean logic

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -10,12 +10,12 @@ require 'celluloid/notices'
 
 $CELLULOID_BACKPORTED = false
 
-if ENV['CELLULOID_BACKPORTED'] == 'silently' or ( defined? $CELLULOID_BACKPORTED and $CELLULOID_BACKPORTED == :silently )
+if ENV['CELLULOID_BACKPORTED'] == 'silently' || ( defined?($CELLULOID_BACKPORTED) && $CELLULOID_BACKPORTED == :silently )
   $CELLULOID_BACKPORTED = true
 else
-  $CELLULOID_BACKPORTED = false if defined? CELLULOID_FUTURE and CELLULOID_FUTURE == true
-  $CELLULOID_BACKPORTED = ( ENV['CELLULOID_BACKPORTED'] != 'false' ) unless defined? $CELLULOID_BACKPORTED
-  Celluloid::Notices.backported if $CELLULOID_BACKPORTED 
+  $CELLULOID_BACKPORTED = false if defined?(CELLULOID_FUTURE) && CELLULOID_FUTURE
+  $CELLULOID_BACKPORTED = ( ENV['CELLULOID_BACKPORTED'] != 'false' ) unless defined?($CELLULOID_BACKPORTED)
+  Celluloid::Notices.backported if $CELLULOID_BACKPORTED
 end
 
 module Celluloid
@@ -500,7 +500,7 @@ require 'celluloid/future'
 
 require 'celluloid/actor_system'
 
-require 'celluloid/depreciate' unless $CELLULOID_BACKPORTED == false or defined? CELLULOID_FUTURE
+require 'celluloid/depreciate' unless $CELLULOID_BACKPORTED == false || defined?(CELLULOID_FUTURE)
 
 $CELLULOID_MONITORING = false
 Celluloid::Notices.output

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -85,7 +85,7 @@ module Celluloid
         monitoring?(actor) && Thread.current[:celluloid_actor].links.include?(actor)
       end
 
-      unless RUBY_PLATFORM == "java" or RUBY_ENGINE == "rbx"
+      unless RUBY_PLATFORM == "java" || RUBY_ENGINE == "rbx"
         # Forcibly kill a given actor
         def kill(actor)
           actor.thread.kill

--- a/lib/celluloid/actor_system.rb
+++ b/lib/celluloid/actor_system.rb
@@ -138,7 +138,7 @@ module Celluloid
       end
     rescue Timeout::Error
       Internals::Logger.error("Couldn't cleanly terminate all actors in #{shutdown_timeout} seconds!")
-      unless RUBY_PLATFORM == "java" or RUBY_ENGINE == "rbx"
+      unless RUBY_PLATFORM == "java" || RUBY_ENGINE == "rbx"
         actors.each do |actor|
           begin
             Actor.kill(actor)

--- a/spec/celluloid/actor_spec.rb
+++ b/spec/celluloid/actor_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe Celluloid, actor_system: :global do
     expect(actor.send('foo')).to eq('oof')
   end
 
-  if RUBY_PLATFORM == "java" and Celluloid.task_class != Celluloid::Task::Fibered
+  if RUBY_PLATFORM == "java" && Celluloid.task_class != Celluloid::Task::Fibered
     context "when executing under JRuby" do
       let(:actor) do
         Class.new do
@@ -498,7 +498,7 @@ RSpec.describe Celluloid, actor_system: :global do
       specify { expect(actor).not_to be_alive }
     end
 
-    unless RUBY_PLATFORM == "java" or RUBY_ENGINE == "rbx"
+    unless RUBY_PLATFORM == "java" || RUBY_ENGINE == "rbx"
       context "when killed" do
         before do
           Celluloid::Actor.kill(actor)


### PR DESCRIPTION
Where there is no control-flow trickery, only simple if/unless statements, we can use `&&` and `||`.

[Avdi Grimm made a fine screencast on the and/or feature](http://devblog.avdi.org/2014/08/26/how-to-use-rubys-english-andor-operators-without-going-nuts/) and how best to use it.

One more thing: what are the possible values of `CELLULOID_FUTURE`? Did it ever get set? It was introduced in this file in 2013. Can not find reference to it in this repo.