### PR TITLE
Execute block on receiver together with exclusive mode

### DIFF
--- a/lib/celluloid/call/sync.rb
+++ b/lib/celluloid/call/sync.rb
@@ -28,6 +28,18 @@ module Celluloid
         Internals::CallChain.current_id = nil
       end
 
+      def check(obj)
+        super
+
+        if task && block && block.execute_on_sender? && task.exclusive?
+          raise "Cannot execute blocks on sender in exclusive mode"
+        end
+      rescue AbortError
+        raise
+      rescue => ex
+        raise AbortError.new(ex)
+      end
+
       def cleanup
         exception = DeadActorError.new("attempted to call a dead actor")
         respond Internals::Response::Error.new(self, exception)

--- a/lib/celluloid/call/sync.rb
+++ b/lib/celluloid/call/sync.rb
@@ -29,11 +29,11 @@ module Celluloid
       end
 
       def check(obj)
-        super
-
         if task && block && block.execute_on_sender? && task.exclusive?
           fail "Cannot execute blocks on sender in exclusive mode"
         end
+
+        super
       end
 
       def cleanup

--- a/lib/celluloid/call/sync.rb
+++ b/lib/celluloid/call/sync.rb
@@ -32,12 +32,8 @@ module Celluloid
         super
 
         if task && block && block.execute_on_sender? && task.exclusive?
-          raise "Cannot execute blocks on sender in exclusive mode"
+          fail "Cannot execute blocks on sender in exclusive mode"
         end
-      rescue AbortError
-        raise
-      rescue => ex
-        raise AbortError.new(ex)
       end
 
       def cleanup

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -7,10 +7,6 @@ module Celluloid
       @retry = 0
       @method, @arguments = method, arguments
       if block
-        if Celluloid.exclusive?
-          # FIXME: nicer exception
-          fail "Cannot execute blocks on sender in exclusive mode"
-        end
         @block = Proxy::Block.new(self, Celluloid.mailbox, block)
       else
         @block = nil

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -18,7 +18,12 @@ module Celluloid
     end
 
     def dispatch(obj)
-      check(obj)
+      begin
+        check(obj)
+      rescue => error
+        raise AbortError.new(error)
+      end
+
       _b = @block && @block.to_proc
       obj.public_send(@method, *@arguments, &_b)
       #     rescue Celluloid::TimeoutError => ex
@@ -45,8 +50,6 @@ module Celluloid
         mandatory_args = -arity - 1
         fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{mandatory_args}+)" if arguments.size < mandatory_args
       end
-    rescue => ex
-      raise AbortError.new(ex)
     end
   end
 end

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -21,7 +21,7 @@ module Celluloid
       begin
         check(obj)
       rescue => error
-        raise AbortError.new(error)
+        raise AbortError, error
       end
 
       _b = @block && @block.to_proc
@@ -44,11 +44,14 @@ module Celluloid
 
       arity = meth.arity
 
-      if arity >= 0
-        fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{arity})" if @arguments.size != arity
+      if arity >= 0 && @arguments.size != arity
+        fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{arity})"
       elsif arity < -1
         mandatory_args = -arity - 1
-        fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{mandatory_args}+)" if arguments.size < mandatory_args
+
+        if arguments.size < mandatory_args
+          fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{mandatory_args}+)"
+        end
       end
     end
   end

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -24,8 +24,7 @@ module Celluloid
         raise AbortError, error
       end
 
-      _b = @block && @block.to_proc
-      obj.public_send(@method, *@arguments, &_b)
+      obj.public_send(@method, *@arguments, &@block)
       #     rescue Celluloid::TimeoutError => ex
       #       raise ex unless ( @retry += 1 ) <= RETRY_CALL_LIMIT
       #       puts "retrying"

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -6,11 +6,7 @@ module Celluloid
     def initialize(method, arguments = [], block = nil)
       @retry = 0
       @method, @arguments = method, arguments
-      if block
-        @block = Proxy::Block.new(self, Celluloid.mailbox, block)
-      else
-        @block = nil
-      end
+      @block = block && Proxy::Block.new(self, Celluloid.mailbox, block)
     end
 
     def execute_block_on_receiver

--- a/lib/celluloid/proxy/block.rb
+++ b/lib/celluloid/proxy/block.rb
@@ -10,8 +10,12 @@ module Celluloid
       attr_writer :execution
       attr_reader :call, :block
 
+      def execute_on_sender?
+        @execution == :sender
+      end
+
       def to_proc
-        if @execution == :sender
+        if execute_on_sender?
           lambda do |*values|
             if task = Thread.current[:celluloid_task]
               @mailbox << Call::Block.new(self, Celluloid::Actor.current.mailbox, values)

--- a/spec/celluloid/block_spec.rb
+++ b/spec/celluloid/block_spec.rb
@@ -7,21 +7,22 @@ RSpec.describe "Blocks", actor_system: :global do
     end
     attr_reader :name
 
-    def ask_for_something(other)
+    def ask_for_something(other, trace = [])
       sender_actor = current_actor
-      $data << [:outside, @name, current_actor.name]
-      other.do_something_and_callback do |value|
-        $data << [:yielded, @name, current_actor.name]
-        $data << receive_result(:self)
-        $data << current_actor.receive_result(:current_actor)
-        $data << sender_actor.receive_result(:sender)
+      trace << [:outside, @name, current_actor.name]
+      other.do_something_and_callback(trace) do |value|
+        trace << [:yielded, @name, current_actor.name]
+        trace << self.receive_result(:self)
+        trace << current_actor.receive_result(:current_actor)
+        trace << sender_actor.receive_result(:sender)
         "somevalue"
       end
+      trace
     end
 
-    def do_something_and_callback
-      $data << [:something, @name, current_actor.name]
-      $data << yield(:foo)
+    def do_something_and_callback(trace)
+      trace << [:something, @name, current_actor.name]
+      trace << yield(:foo)
     end
 
     def receive_result(result)
@@ -29,15 +30,12 @@ RSpec.describe "Blocks", actor_system: :global do
     end
   end
 
-  it "works" do
-    $data = []
-
+  it "executes blocks on sender" do
     a1 = MyBlockActor.new("one")
     a2 = MyBlockActor.new("two")
 
-    a1.ask_for_something a2
-
-    expected = [
+    trace = a1.ask_for_something a2
+    expect(trace).to eq([
       [:outside, "one", "one"],
       [:something, "two", "two"],
       [:yielded, "one", "one"],
@@ -45,8 +43,6 @@ RSpec.describe "Blocks", actor_system: :global do
       [:current_actor, "one", "one"],
       [:sender, "one", "one"],
       "somevalue",
-    ]
-
-    expect($data).to eq(expected)
+    ])
   end
 end

--- a/spec/celluloid/block_spec.rb
+++ b/spec/celluloid/block_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe "Blocks", actor_system: :global do
     attr_reader :name
 
     def ask_for_something(other, trace = [])
-      sender_actor = current_actor
-      trace << [:outside, @name, current_actor.name]
+      sender_actor = Actor.current
+      trace << [:outside, @name, Actor.current.name]
       other.do_something_and_callback(trace) do |value|
-        trace << [:yielded, @name, current_actor.name]
+        trace << [:yielded, @name, Actor.current.name]
         trace << self.receive_result(:self)
-        trace << current_actor.receive_result(:current_actor)
+        trace << Actor.current.receive_result(:current_actor)
         trace << sender_actor.receive_result(:sender)
         "somevalue"
       end
@@ -21,12 +21,12 @@ RSpec.describe "Blocks", actor_system: :global do
     end
 
     def do_something_and_callback(trace)
-      trace << [:something, @name, current_actor.name]
+      trace << [:something, @name, Actor.current.name]
       trace << yield(:foo)
     end
 
     def receive_result(result)
-      [result, @name, current_actor.name]
+      [result, @name, Actor.current.name]
     end
   end
 


### PR DESCRIPTION
Executing the block on the receiver is essentially passing the block as-is without wrapping it in Celluloidy magic to pass execution back and forth. I was expecting to be able to pass a block to a method and execute it on the receiver during exclusive mode, but I was not.

```ruby
require "bundler/setup"
require "celluloid"

Celluloid.logger = nil

class A
  include Celluloid

  def exclusive_on_receiver
    b = B.new
    exclusive { b.on_receiver { $stderr.puts "OK" } }
  end
end

class B
  include Celluloid

  execute_block_on_receiver def on_receiver(&block)
    yield
  end
end

begin
  A.new.exclusive_on_receiver
rescue => error
  $stderr.puts "ERROR: #exclusive_on_receiver (#{error})"
end
```

I understand executing blocks during exclusive mode could cause deadlock issues, but that is true for anything performed under exclusive mode. Is there some other reason that this does not work that I am not seeing?