### PR TITLE
Ensure @busy is initialized before initializing workers

### DIFF
--- a/lib/celluloid/pool_manager.rb
+++ b/lib/celluloid/pool_manager.rb
@@ -16,11 +16,11 @@ module Celluloid
       @worker_class = worker_class
       @args = options[:args] ? Array(options[:args]) : []
 
-      @idle = @size.times.map { worker_class.new_link(*@args) }
-
       # FIXME: Another data structure (e.g. Set) would be more appropriate
       # here except it causes MRI to crash :o
       @busy = []
+
+      @idle = @size.times.map { worker_class.new_link(*@args) }
     end
 
     def __shutdown__


### PR DESCRIPTION
If worker actors do work on initialization, an exception there will crash Celluloid when the crash recovery attempts to delete the worker from the `@busy` array. If we initialize `@busy` before creating the workers this can't happen.

Here's a simple reproduction of the issue:

```ruby
require 'celluloid'

class Worker
  include Celluloid

  def initialize
    async.poll
  end

  def poll
    # Poll an API and do work, but sometimes it fails:
    raise "oops"
  end
end

class Supervisor < Celluloid::SupervisionGroup
  pool Worker, as: :worker_pool, size: 10
end

Supervisor.run
```

This results in:

```
NoMethodError: undefined method `delete' for nil:NilClass
        /Users/louis.simoneau/.gem/ruby/2.2.0/gems/celluloid-0.16.0/lib/celluloid/pool_manager.rb:126:in `__crash_handler__'
```

By initializing `@busy` before starting the workers, we ensure that even if they crash very quickly they won't take down Celluloid with them.