### PR TITLE
Docs, minor clarification.

### DIFF
--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -218,7 +218,8 @@ module Celluloid
     def wait(name)
       @signals.wait name
     end
-
+    
+    # Register a new handler for a given pattern
     def handle(*patterns, &block)
       @handlers.handle(*patterns, &block)
     end


### PR DESCRIPTION
Clarification added that explains that the `Actor#handle` method registers handlers for a given pattern.