### PR TITLE
Refactor (Standard)Errors vs. (Signal)Exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ rvm:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: rbx-2
     - rvm: ruby-head
     - rvm: jruby-head
     - env: CELLULOID_BACKPORTED=true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * `Celluloid::ActorSystem` moved to `Celluloid::Actor::System`, and from `celluloid/actor_system.rb` to `celluloid/actor/system.rb`
 * Added extensible API for defining new SystemEvents, and having them handled... without everyone changing `Actor#handle_system_event`.
 * Deprecated Task::TerminatedError & Task::TimeoutError... Consolidated in exceptions.rb, inherited from SignalExceptions vs. StandardError.
+* General round-up of all Errors emitted throughout Celluloid, to either be derived from `Celluloid::Error` or `Celluloid::Interruption`.
 
 0.17.0 (2015-07-04)
 -----

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 -----
 * `Celluloid::ActorSystem` moved to `Celluloid::Actor::System`, and from `celluloid/actor_system.rb` to `celluloid/actor/system.rb`
 * Added extensible API for defining new SystemEvents, and having them handled... without everyone changing `Actor#handle_system_event`.
+* Deprecated Task::TerminatedError & Task::TimeoutError... Consolidated in exceptions.rb, inherited from SignalExceptions vs. StandardError.
 
 0.17.0 (2015-07-04)
 -----

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 -----
 * `Celluloid::ActorSystem` moved to `Celluloid::Actor::System`, and from `celluloid/actor_system.rb` to `celluloid/actor/system.rb`
 * Added extensible API for defining new SystemEvents, and having them handled... without everyone changing `Actor#handle_system_event`.
-* Deprecated Task::TerminatedError & Task::TimeoutError... Consolidated in exceptions.rb, inherited from SignalExceptions vs. StandardError.
-* General round-up of all Errors emitted throughout Celluloid, to either be derived from `Celluloid::Error` or `Celluloid::Interruption`.
+* Deprecated Task::TerminatedError & Task::TimeoutError... Consolidated in exceptions.rb, inherited from Exceptions vs. StandardError.
+* General round-up of all "errors" emitted throughout Celluloid, to either be derived from `Celluloid::Error` or `Celluloid::Interruption`.
 
 0.17.0 (2015-07-04)
 -----

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -167,9 +167,9 @@ module Celluloid
       end
 
       shutdown
-    rescue Exception => ex
+    rescue ::Exception => ex
       handle_crash(ex)
-      raise unless ex.is_a? StandardError
+      raise unless ex.is_a?(StandardError) #de || ex.is_a?(Celluloid::Exception)
     end
 
     # Terminate this actor
@@ -190,7 +190,7 @@ module Celluloid
               msg.actor.mailbox.address == receiver.mailbox.address &&
               msg.type == type
             end
-          rescue TimeoutError
+          rescue TaskTimeout
             next # IO reactor did something, no message in queue yet.
           end
 
@@ -205,7 +205,7 @@ module Celluloid
           end
         end
 
-        fail TimeoutError, "linking timeout of #{LINKING_TIMEOUT} seconds exceeded with receiver: #{receiver}"
+        fail TaskTimeout, "linking timeout of #{LINKING_TIMEOUT} seconds exceeded with receiver: #{receiver}"
       end
     end
 
@@ -247,7 +247,7 @@ module Celluloid
       bt = caller
       task = Task.current
       timer = @timers.after(duration) do
-        exception = Task::TimeoutError.new("execution expired")
+        exception = TaskTimeout.new("execution expired")
         exception.set_backtrace bt
         task.resume exception
       end

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -169,7 +169,7 @@ module Celluloid
       shutdown
     rescue ::Exception => ex
       handle_crash(ex)
-      raise unless ex.is_a?(StandardError)
+      raise unless ex.is_a?(StandardError) || ex.is_a?(Celluloid::Interruption)
     end
 
     # Terminate this actor

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -169,7 +169,7 @@ module Celluloid
       shutdown
     rescue ::Exception => ex
       handle_crash(ex)
-      raise unless ex.is_a?(StandardError) #de || ex.is_a?(Celluloid::Exception)
+      raise unless ex.is_a?(StandardError)
     end
 
     # Terminate this actor

--- a/lib/celluloid/actor/system.rb
+++ b/lib/celluloid/actor/system.rb
@@ -37,10 +37,6 @@ module Celluloid
 
       attr_reader :registry, :group
 
-      module Error
-        class Uninitialized < StandardError; end
-      end
-
       # the root of the supervisor tree is established at supervision/root
 
       def root_services

--- a/lib/celluloid/call/sync.rb
+++ b/lib/celluloid/call/sync.rb
@@ -15,7 +15,7 @@ module Celluloid
         Internals::CallChain.current_id = @chain_id
         result = super(obj)
         respond Internals::Response::Success.new(self, result)
-      rescue Exception => ex
+      rescue ::Exception => ex
         # Exceptions that occur during synchronous calls are reraised in the
         # context of the sender
         respond Internals::Response::Error.new(self, ex)

--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -26,10 +26,10 @@ module Celluloid
       check(obj)
       _b = @block && @block.to_proc
       obj.public_send(@method, *@arguments, &_b)
-      #     rescue Celluloid::TimeoutError => ex
+      #     rescue Celluloid::TaskTimeout => ex
       #       raise ex unless ( @retry += 1 ) <= RETRY_CALL_LIMIT
       #       puts "retrying"
-      #       Internals::Logger.warn("TimeoutError at Call dispatch. Retrying in #{RETRY_CALL_WAIT} seconds. ( Attempt #{@retry} of #{RETRY_CALL_LIMIT} )")
+      #       Internals::Logger.warn("TaskTimeout at Call dispatch. Retrying in #{RETRY_CALL_WAIT} seconds. ( Attempt #{@retry} of #{RETRY_CALL_LIMIT} )")
       #       sleep RETRY_CALL_WAIT
       #       retry
     end
@@ -51,6 +51,7 @@ module Celluloid
         fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{mandatory_args}+)" if arguments.size < mandatory_args
       end
     rescue => ex
+      puts "THERE #{ex}"
       raise AbortError.new(ex)
     end
   end

--- a/lib/celluloid/condition.rb
+++ b/lib/celluloid/condition.rb
@@ -21,7 +21,7 @@ module Celluloid
             msg.is_a?(SignalConditionRequest) && msg.task == Thread.current
           end
         rescue TimedOut
-          raise ConditionTimedOut, "timeout after #{@timeout.inspect} seconds"
+          raise ConditionError, "timeout after #{@timeout.inspect} seconds"
         end until message
 
         message.value
@@ -42,7 +42,7 @@ module Celluloid
         if timeout
           bt = caller
           timer = actor.timers.after(timeout) do
-            exception = ConditionTimedOut.new("timeout after #{timeout.inspect} seconds")
+            exception = ConditionError.new("timeout after #{timeout.inspect} seconds")
             exception.set_backtrace bt
             task.resume exception
           end
@@ -58,7 +58,7 @@ module Celluloid
 
       result = Celluloid.suspend :condwait, waiter
       timer.cancel if timer
-      fail result if result.is_a?(ConditionError) || result.is_a?(ConditionTimedOut)
+      fail result if result.is_a?(ConditionError)
       result
     end
 

--- a/lib/celluloid/deprecate.rb
+++ b/lib/celluloid/deprecate.rb
@@ -16,4 +16,6 @@ module Celluloid
   TaskThread = Task::Threaded
   TaskFiber = Task::Fibered
   ActorSystem = Actor::System
+  Task::TerminatedError = TaskTerminated
+  Task::TimeoutError = TaskTimeout
 end

--- a/lib/celluloid/exceptions.rb
+++ b/lib/celluloid/exceptions.rb
@@ -1,6 +1,6 @@
 module Celluloid
   class Error              < StandardError;             end
-  class Interruption       < SignalException;           end
+  class Interruption       < Exception;                 end
   class TimedOut           < Celluloid::Interruption;   end # Distinguished from `Timeout`
   class StillActive        < Celluloid::Error;          end
   class NotActive          < Celluloid::Error;          end
@@ -11,7 +11,6 @@ module Celluloid
   class TaskTerminated     < Celluloid::Interruption;   end # Kill a running task after terminate
   class TaskTimeout        < Celluloid::TimedOut;       end # A timeout occured before the given request could complete
   class ConditionError     < Celluloid::Error;          end
-  class ConditionTimedOut  < Celluloid::TimedOut;       end
   class AbortError         < Celluloid::Error           # The sender made an error, not the current actor
     attr_reader :cause
     def initialize(cause)

--- a/lib/celluloid/exceptions.rb
+++ b/lib/celluloid/exceptions.rb
@@ -4,7 +4,6 @@ module Celluloid
   class TimedOut           < Celluloid::Interruption;   end # Distinguished from `Timeout`
   class StillActive        < Celluloid::Error;          end
   class NotActive          < Celluloid::Error;          end
-  class NotImplemented     < Celluloid::Error;          end
   class NotActorError      < Celluloid::Error;          end # Don't do Actor-like things outside Actor scope
   class DeadActorError     < Celluloid::Error;          end # Trying to do something to a dead actor
   class NotTaskError       < Celluloid::Error;          end # Asked to do task-related things outside a task

--- a/lib/celluloid/exceptions.rb
+++ b/lib/celluloid/exceptions.rb
@@ -1,20 +1,20 @@
 module Celluloid
-  # Base class of all Celluloid errors
-  Error = Class.new(StandardError)
-
-  # Don't do Actor-like things outside Actor scope
-  NotActorError = Class.new(Celluloid::Error)
-
-  # Trying to do something to a dead actor
-  DeadActorError = Class.new(Celluloid::Error)
-
-  # A timeout occured before the given request could complete
-  TimeoutError = Class.new(Celluloid::Error)
-
-  # The sender made an error, not the current actor
-  class AbortError < Celluloid::Error
+  class Error              < StandardError;             end
+  class Interruption       < SignalException;           end
+  class TimedOut           < Celluloid::Interruption;   end # Distinguished from `Timeout`
+  class StillActive        < Celluloid::Error;          end
+  class NotActive          < Celluloid::Error;          end
+  class NotImplemented     < Celluloid::Error;          end
+  class NotActorError      < Celluloid::Error;          end # Don't do Actor-like things outside Actor scope
+  class DeadActorError     < Celluloid::Error;          end # Trying to do something to a dead actor
+  class NotTaskError       < Celluloid::Error;          end # Asked to do task-related things outside a task
+  class DeadTaskError      < Celluloid::Error;          end # Trying to resume a dead task
+  class TaskTerminated     < Celluloid::Interruption;   end # Kill a running task after terminate
+  class TaskTimeout        < Celluloid::TimedOut;       end # A timeout occured before the given request could complete
+  class ConditionError     < Celluloid::Error;          end
+  class ConditionTimedOut  < Celluloid::TimedOut;       end
+  class AbortError         < Celluloid::Error           # The sender made an error, not the current actor
     attr_reader :cause
-
     def initialize(cause)
       @cause = cause
       super "caused by #{cause.inspect}: #{cause}"

--- a/lib/celluloid/future.rb
+++ b/lib/celluloid/future.rb
@@ -91,7 +91,7 @@ module Celluloid
       if result
         result.value
       else
-        fail TimeoutError, "Timed out"
+        fail TimedOut, "Timed out"
       end
     end
     alias_method :call, :value

--- a/lib/celluloid/group.rb
+++ b/lib/celluloid/group.rb
@@ -48,15 +48,15 @@ module Celluloid
     end
 
     def get
-      fail Celluloid::NotImplemented
+      fail NotImplementedError
     end
 
     def create
-      fail Celluloid::NotImplemented
+      fail NotImplementedError
     end
 
     def shutdown
-      fail Celluloid::NotImplemented
+      fail NotImplementedError
     end
   end
 end

--- a/lib/celluloid/group.rb
+++ b/lib/celluloid/group.rb
@@ -1,8 +1,5 @@
 module Celluloid
   class Group
-    class NotImplemented < StandardError; end
-    class StillActive < StandardError; end
-    class NotActive < StandardError; end
 
     attr_accessor :group
 
@@ -13,7 +10,7 @@ module Celluloid
     end
 
     def assert_active
-      fail NotActive unless active?
+      fail Celluloid::NotActive unless active?
     end
 
     def assert_inactive
@@ -21,7 +18,7 @@ module Celluloid
       if RUBY_PLATFORM == "java"
         Celluloid.logger.warn "Group is still active"
       else
-        fail StillActive
+        fail Celluloid::StillActive
       end
     end
 
@@ -51,15 +48,15 @@ module Celluloid
     end
 
     def get
-      fail NotImplemented
+      fail Celluloid::NotImplemented
     end
 
     def create
-      fail NotImplemented
+      fail Celluloid::NotImplemented
     end
 
     def shutdown
-      fail NotImplemented
+      fail Celluloid::NotImplemented
     end
   end
 end

--- a/lib/celluloid/group/pool.rb
+++ b/lib/celluloid/group/pool.rb
@@ -93,7 +93,7 @@ module Celluloid
           while proc = queue.pop
             begin
               proc.call
-            rescue Exception => ex
+            rescue ::Exception => ex
               Internals::Logger.crash("thread crashed", ex)
             ensure
               put thread

--- a/lib/celluloid/group/spawner.rb
+++ b/lib/celluloid/group/spawner.rb
@@ -25,7 +25,6 @@ module Celluloid
             th.kill
             queue << th
           end
-
           loop do
             break if queue.empty?
             queue.pop.join
@@ -52,7 +51,7 @@ module Celluloid
 
           begin
             proc.call
-          rescue Exception => ex
+          rescue ::Exception => ex
             Internals::Logger.crash("thread crashed", ex)
             Thread.current[:celluloid_meta][:state] = :error
           ensure

--- a/lib/celluloid/mailbox.rb
+++ b/lib/celluloid/mailbox.rb
@@ -70,7 +70,7 @@ module Celluloid
     end
 
     # Receive a letter from the mailbox. Guaranteed to return a message. If
-    # timeout is exceeded, raise a TimeoutError.
+    # timeout is exceeded, raise a TaskTimeout.
     def receive(timeout = nil, &block)
       message = nil
       Timers::Wait.for(timeout) do |remaining|
@@ -78,7 +78,7 @@ module Celluloid
         break if message
       end
       return message if message
-      fail TimeoutError.new("receive timeout exceeded")
+      fail TaskTimeout.new("receive timeout exceeded")
     end
 
     # Shut down this mailbox and clean up its contents

--- a/lib/celluloid/proxies.rb
+++ b/lib/celluloid/proxies.rb
@@ -1,12 +1,11 @@
 module Celluloid
   module Proxy
+    require "celluloid/proxy/abstract"
+    require "celluloid/proxy/sync"
+    require "celluloid/proxy/cell"
+    require "celluloid/proxy/actor"
+    require "celluloid/proxy/async"
+    require "celluloid/proxy/future"
+    require "celluloid/proxy/block"
   end
 end
-
-require "celluloid/proxy/abstract"
-require "celluloid/proxy/sync"
-require "celluloid/proxy/cell"
-require "celluloid/proxy/actor"
-require "celluloid/proxy/async"
-require "celluloid/proxy/future"
-require "celluloid/proxy/block"

--- a/lib/celluloid/task.rb
+++ b/lib/celluloid/task.rb
@@ -1,18 +1,7 @@
 module Celluloid
-  # Asked to do task-related things outside a task
-  class NotTaskError < Celluloid::Error; end
-
-  # Trying to resume a dead task
-  class DeadTaskError < Celluloid::Error; end
-
-  # Errors which should be resumed automatically
-  class ResumableError < Celluloid::Error; end
 
   # Tasks are interruptable/resumable execution contexts used to run methods
   class Task
-    class TerminatedError < ResumableError; end # kill a running task after terminate
-
-    class TimeoutError < ResumableError; end # kill a running task after timeout
 
     # Obtain the current task
     def self.current
@@ -55,7 +44,7 @@ module Celluloid
 
           actor.tasks << self
           yield
-        rescue Task::TerminatedError
+        rescue TaskTerminated
           # Task was explicitly terminated
         ensure
           name_current_thread nil
@@ -85,8 +74,7 @@ module Celluloid
       value = signal
 
       @status = :running
-      fail value if value.is_a?(Celluloid::ResumableError)
-
+      fail value if value.is_a?(Celluloid::Interruption)
       value
     end
 
@@ -126,7 +114,7 @@ module Celluloid
             logger.send(type, "Terminating task: type=#{@type.inspect}, meta=#{@meta.inspect}, status=#{@status.inspect}")
           end
         end
-        exception = Task::TerminatedError.new("task was terminated")
+        exception = TaskTerminated.new("task was terminated")
         exception.set_backtrace(caller)
         resume exception
       else

--- a/lib/celluloid/task/threaded.rb
+++ b/lib/celluloid/task/threaded.rb
@@ -18,10 +18,10 @@ module Celluloid
         thread = Internals::ThreadHandle.new(Thread.current[:celluloid_actor_system], :task) do
           begin
             ex = @resume_queue.pop
-            fail ex if ex.is_a?(Task::TerminatedError)
+            fail ex if ex.is_a?(TaskTerminated)
 
             yield
-          rescue Exception => ex
+          rescue ::Exception => ex
             @exception_queue << ex
           ensure
             @yield_mutex.synchronize do

--- a/spec/celluloid/actor/system_spec.rb
+++ b/spec/celluloid/actor/system_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Celluloid::Actor::System do
     subject.shutdown
 
     expect { subject.get_thread }
-      .to raise_error(Celluloid::Group::NotActive)
+      .to raise_error(Celluloid::NotActive)
   end
 
   it "warns nicely when no actor system is started" do

--- a/spec/celluloid/condition_spec.rb
+++ b/spec/celluloid/condition_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe Celluloid::Condition, actor_system: :global do
   it "times out inside normal Threads" do
     condition = Celluloid::Condition.new
     expect { condition.wait(1) }
-      .to raise_error(Celluloid::ConditionError)
+      .to raise_error(Celluloid::ConditionTimedOut)
   end
 
   it "times out inside Tasks" do
-    allow(logger).to receive(:crash).with("Actor crashed!", Celluloid::ConditionError)
+    allow(logger).to receive(:crash).with("Actor crashed!", Celluloid::ConditionTimedOut)
     expect { actor.wait_for_condition(1) }
-      .to raise_error(Celluloid::ConditionError)
+      .to raise_error(Celluloid::ConditionTimedOut)
   end
 end

--- a/spec/celluloid/condition_spec.rb
+++ b/spec/celluloid/condition_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe Celluloid::Condition, actor_system: :global do
   it "times out inside normal Threads" do
     condition = Celluloid::Condition.new
     expect { condition.wait(1) }
-      .to raise_error(Celluloid::ConditionTimedOut)
+      .to raise_error(Celluloid::ConditionError)
   end
 
   it "times out inside Tasks" do
-    allow(logger).to receive(:crash).with("Actor crashed!", Celluloid::ConditionTimedOut)
+    allow(logger).to receive(:crash).with("Actor crashed!", Celluloid::ConditionError)
     expect { actor.wait_for_condition(1) }
-      .to raise_error(Celluloid::ConditionTimedOut)
+      .to raise_error(Celluloid::ConditionError)
   end
 end

--- a/spec/celluloid/future_spec.rb
+++ b/spec/celluloid/future_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Celluloid::Future, actor_system: :global do
     expect(future).to be_ready
   end
 
-  it "raises TimeoutError when the future times out" do
+  it "raises TaskTimeout when the future times out" do
     future = Celluloid::Future.new { sleep 2 }
-    expect { future.value(1) }.to raise_exception(Celluloid::TimeoutError)
+    expect { future.value(1) }.to raise_exception(Celluloid::TaskTimeout)
   end
 end

--- a/spec/deprecate/actor_system_spec.rb
+++ b/spec/deprecate/actor_system_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Deprecated Celluloid::ActorSystem" do
     subject.shutdown
 
     expect { subject.get_thread }
-      .to raise_error(Celluloid::Group::NotActive)
+      .to raise_error(Celluloid::NotActive)
   end
 
   it "warns nicely when no actor system is started" do

--- a/spec/deprecate/future_spec.rb
+++ b/spec/deprecate/future_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "Deprecated Celluloid::Future", actor_system: :global do
     expect(future).to be_ready
   end
 
-  it "raises TimeoutError when the future times out" do
+  it "raises TaskTimeout when the future times out" do
     future = Celluloid::Future.new { sleep 2 }
-    expect { future.value(1) }.to raise_exception(Celluloid::TimeoutError)
+    expect { future.value(1) }.to raise_exception(Celluloid::TaskTimeout)
   end
 end unless $CELLULOID_BACKPORTED == false

--- a/spec/shared/actor_examples.rb
+++ b/spec/shared/actor_examples.rb
@@ -225,7 +225,7 @@ RSpec.shared_examples "a Celluloid Actor" do
 
     it "warns about suspending the finalizer" do
       allow(logger).to receive(:warn)
-      allow(logger).to receive(:crash).with(/finalizer crashed!/, Celluloid::Task::TerminatedError)
+      allow(logger).to receive(:crash).with(/finalizer crashed!/, Celluloid::TaskTerminated)
       expect(logger).to receive(:warn).with(/Dangerously suspending task: type=:finalizer, meta={:dangerous_suspend=>true, :method_name=>:cleanup}, status=:sleeping/)
       actor.terminate
       Specs.sleep_and_wait_until { !actor.alive? }
@@ -1216,9 +1216,9 @@ RSpec.shared_examples "a Celluloid Actor" do
     let(:a1) { actor_class.new }
     let(:a2) { actor_class.new }
 
-    it "allows timing out tasks, raising Celluloid::Task::TimeoutError" do
-      allow(logger).to receive(:crash).with("Actor crashed!", Celluloid::Task::TimeoutError)
-      expect { a1.ask_name_with_timeout a2, 0.3 }.to raise_error(Celluloid::Task::TimeoutError)
+    it "allows timing out tasks, raising Celluloid::TaskTimeout" do
+      allow(logger).to receive(:crash).with("Actor crashed!", Celluloid::TaskTimeout)
+      expect { a1.ask_name_with_timeout a2, 0.3 }.to raise_error(Celluloid::TaskTimeout)
       Specs.sleep_and_wait_until { !a1.alive? }
     end
 

--- a/spec/shared/group_examples.rb
+++ b/spec/shared/group_examples.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples "a Celluloid Group" do
     wait_until_idle
   end
 
-  [StandardError, Exception].each do |exception_class|
+  [::StandardError, ::Exception].each do |exception_class|
     context "with an #{exception_class} in the thread" do
       before do
         @wait_queue = Queue.new # doesn't work if in a let()

--- a/spec/shared/mailbox_examples.rb
+++ b/spec/shared/mailbox_examples.rb
@@ -43,7 +43,7 @@ RSpec.shared_examples "a Celluloid Mailbox" do
 
     expect do
       subject.receive(interval) { false }
-    end.to raise_exception(Celluloid::TimeoutError)
+    end.to raise_exception(Celluloid::TaskTimeout)
 
     # Just check to make sure it didn't return earlier
     expect(Time.now - started_at).to be >= interval

--- a/tasks/benchmarks.rake
+++ b/tasks/benchmarks.rake
@@ -7,7 +7,7 @@ task :benchmark do
       glob = File.expand_path("../../benchmarks/*.rb", __FILE__)
       Dir[glob].each { |benchmark| load benchmark }
     end
-  rescue Exception, Timeout::Error => ex
+  rescue ::Exception, Timeout::Error => ex
     puts "ERROR: Couldn't complete benchmark: #{ex.class}: #{ex}"
     puts "  #{ex.backtrace.join("\n  ")}"
 


### PR DESCRIPTION
Closes #424

Introduces varies of `*::TimedOut` which along with `TaskTerminated` are `Celluloid::Interruption` subclasses, deriving from `SignalException` ( seen as an in-process `Interrupt` rather than an "Error" )

/cc: @ioquatix 