### PR TITLE
Advise to load submodules for using pre-release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you don't get anywhere with this checklist, please feel free to [file a bug r
 If you encounter a bug, it's entirely possible that it has already been fixed but not yet included in a released version. You can establish this by trying to run your application with a pre-release version of Celluloid direct from source control. You can do this by modifying your application's Gemfile as follows:
 
 ```ruby
-gem 'celluloid', github: 'celluloid'
+gem 'celluloid', github: 'celluloid', submodules: true
 ```
 
 If it is suggested to you that you try a different branch, add `branch: 'somebranch'`.


### PR DESCRIPTION
Without `submodules: true` one would get this error:
```
Fetching git://github.com/celluloid/celluloid.git
There was a LoadError while loading celluloid.gemspec: 
cannot load such file -- /home/vkochnev/.rvm/gems/ruby-2.2.1/bundler/gems/celluloid-995589fc28a2/culture/sync
from
  /home/vkochnev/.rvm/gems/ruby-2.2.1/bundler/gems/celluloid-995589fc28a2/celluloid.gemspec:3:in `<main>'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```