### PR TITLE
Don't catch IOError

### DIFF
--- a/lib/celluloid/mailbox/evented.rb
+++ b/lib/celluloid/mailbox/evented.rb
@@ -31,7 +31,7 @@ module Celluloid
         begin
           current_actor = Thread.current[:celluloid_actor]
           @reactor.wakeup unless current_actor && current_actor.mailbox == self
-        rescue IOError
+        rescue
           Internals::Logger.crash "reactor crashed", $ERROR_INFO
           dead_letter(message)
         end
@@ -51,8 +51,6 @@ module Celluloid
 
         # No message was received:
         return nil
-      rescue IOError
-        raise MailboxShutdown, "mailbox shutdown called during receive"
       end
 
       # Obtain the next message from the mailbox that matches the given block

--- a/spec/celluloid/mailbox/evented_spec.rb
+++ b/spec/celluloid/mailbox/evented_spec.rb
@@ -24,4 +24,17 @@ RSpec.describe Celluloid::Mailbox::Evented do
       expect(Time.now - started_at).to be_within(CelluloidSpecs::TIMER_QUANTUM).of timeout_interval
     end
   end
+
+  it "discard messages when reactor wakeup fails" do
+    expect(Celluloid::Internals::Logger).to receive(:crash).with('reactor crashed', RuntimeError)
+    expect(Celluloid.logger).to receive(:debug).with("Discarded message (mailbox is dead): first")
+
+    bad_reactor = Class.new do
+      def wakeup
+        fail
+      end
+    end
+    mailbox = Celluloid::Mailbox::Evented.new(bad_reactor)
+    mailbox << :first
+  end
 end


### PR DESCRIPTION
Evented mailbox should not know anything about IOError.

Some notes:

1) Method `<<` is changed to catch any error that `wakeup` can raise. It can be not only `IOError`.
2) Method `check` is more interesting. It just converts `IOError` to `MailboxShutdown` and I think it's a cryptic behavior. It is also very related to https://github.com/celluloid/celluloid-io/issues/151. `Celluloid::IO`'s reactor calls `task.resume` inside `run_once`. This can lead to the situation when `IOError` is caught by mistake (raised by user's code for example or by socket operation). So `MailboxShutdown` should be raised by *reactor* itself but not by generic `Mailbox::Evented` (if there's really any need in this exception — now it's indistinguishable from `MailboxDead` in its behavior) .