### PR TITLE
Remove excess call/block require

### DIFF
--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -59,4 +59,3 @@ end
 require "celluloid/call/sync"
 require "celluloid/call/async"
 require "celluloid/call/block"
-require "celluloid/call/block"


### PR DESCRIPTION
`celluloid/call/block` required twice.

Btw why `Call` class file named `calls`? Maybe better to rename it to `call.rb`?