### PR TITLE
Print out method name to help debugging method call which caused dead…

### DIFF
--- a/lib/celluloid/call/sync.rb
+++ b/lib/celluloid/call/sync.rb
@@ -29,7 +29,7 @@ module Celluloid
       end
 
       def cleanup
-        exception = DeadActorError.new("attempted to call a dead actor")
+        exception = DeadActorError.new("attempted to call a dead actor: #{self.method}")
         respond Internals::Response::Error.new(self, exception)
       end
 

--- a/lib/celluloid/proxy/future.rb
+++ b/lib/celluloid/proxy/future.rb
@@ -18,7 +18,7 @@ class Celluloid::Proxy::Future < Celluloid::Proxy::Abstract
 
   def method_missing(meth, *args, &block)
     unless @mailbox.alive?
-      fail ::Celluloid::DeadActorError, "attempted to call a dead actor"
+      fail ::Celluloid::DeadActorError, "attempted to call a dead actor: #{meth}"
     end
 
     if block_given?

--- a/lib/celluloid/proxy/sync.rb
+++ b/lib/celluloid/proxy/sync.rb
@@ -22,7 +22,7 @@ class Celluloid::Proxy::Sync < Celluloid::Proxy::Abstract
 
   def method_missing(meth, *args, &block)
     unless @mailbox.alive?
-      fail ::Celluloid::DeadActorError, "attempted to call a dead actor"
+      fail ::Celluloid::DeadActorError, "attempted to call a dead actor: #{meth}"
     end
 
     if @mailbox == ::Thread.current[:celluloid_mailbox]


### PR DESCRIPTION
… actor error.