### PR TITLE
Fix failure to remove dead actors from sets, e.g. celluloid-supervision.

### DIFF
--- a/lib/celluloid/proxy/abstract.rb
+++ b/lib/celluloid/proxy/abstract.rb
@@ -6,7 +6,7 @@ class Celluloid::Proxy::Abstract < BasicObject
   end
 
   # Needed for storing proxies in data structures
-  needed = [:object_id, :__id__, :hash, :private_methods] - instance_methods
+  needed = [:object_id, :__id__, :hash, :eql?, :private_methods] - instance_methods
   if needed.any?
     include ::Kernel.dup.module_eval {
       undef_method(*(instance_methods - needed))

--- a/spec/shared/actor_examples.rb
+++ b/spec/shared/actor_examples.rb
@@ -29,6 +29,17 @@ RSpec.shared_examples "a Celluloid Actor" do
   it "can be stored in hashes" do
     expect(actor.hash).not_to eq(Kernel.hash)
     expect(actor.object_id).not_to eq(Kernel.object_id)
+    expect(actor.eql? actor).to be_truthy
+  end
+
+  it "can be stored in hashes even when dead" do
+    actor.terminate
+    
+    expect(actor.dead?).to be_truthy
+    
+    expect(actor.hash).not_to eq(Kernel.hash)
+    expect(actor.object_id).not_to eq(Kernel.object_id)
+    expect(actor.eql? actor).to be_truthy
   end
 
   it "implements respond_to? correctly" do


### PR DESCRIPTION
Discussed here:

https://github.com/celluloid/celluloid-supervision/issues/26

This is a pretty important bug fix, it might even warrant being back ported since it's currently breaking our production code.