### PR TITLE
Simplified sync, async and future proxies by providing specific AbstractCall base.

### DIFF
--- a/lib/celluloid/proxy/abstract.rb
+++ b/lib/celluloid/proxy/abstract.rb
@@ -17,3 +17,28 @@ class Celluloid::Proxy::Abstract < BasicObject
     alias_method(:equal?, :==) unless instance_methods.include?(:equal?)
   end
 end
+
+class Celluloid::Proxy::AbstractCall < Celluloid::Proxy::Abstract
+  attr_reader :mailbox
+  
+  def initialize(mailbox, klass)
+    @mailbox = mailbox
+    @klass = klass
+  end
+  
+  def eql?(other)
+    self.__class__.eql?(other.__class__) and @mailbox.eql?(other.mailbox)
+  end
+
+  def hash
+    @mailbox.hash
+  end
+
+  def __klass__
+    @klass
+  end
+
+  def inspect
+    "#<#{self.__class__}(#{@klass})>"
+  end
+end

--- a/lib/celluloid/proxy/abstract.rb
+++ b/lib/celluloid/proxy/abstract.rb
@@ -1,10 +1,14 @@
+module Celluloid::Proxy
+  CLASS_METHOD = ::Kernel.instance_method(:class)
+  
+  # Looks up the actual class of instance, even if instance is a proxy.
+  def self.class_of(instance)
+    CLASS_METHOD.bind(instance).call
+  end
+end
+
 # Base class of Celluloid proxies
 class Celluloid::Proxy::Abstract < BasicObject
-  # Used for reflecting on proxy objects themselves
-  def __class__
-    ::Celluloid::Proxy::Abstract
-  end
-
   # Needed for storing proxies in data structures
   needed = [:object_id, :__id__, :hash, :eql?, :private_methods] - instance_methods
   if needed.any?
@@ -15,6 +19,10 @@ class Celluloid::Proxy::Abstract < BasicObject
     # rubinius bug?  These methods disappear when we include hacked kernel
     define_method :==, ::BasicObject.instance_method(:==) unless instance_methods.include?(:==)
     alias_method(:equal?, :==) unless instance_methods.include?(:equal?)
+  end
+  
+  def __class__
+    @class ||= ::Celluloid::Proxy.class_of(self)
   end
 end
 
@@ -27,17 +35,17 @@ class Celluloid::Proxy::AbstractCall < Celluloid::Proxy::Abstract
   end
   
   def eql?(other)
-    self.__class__.eql?(other.__class__) and @mailbox.eql?(other.mailbox)
+    self.__class__.eql?(::Celluloid::Proxy.class_of(other)) and @mailbox.eql?(other.mailbox)
   end
 
   def hash
     @mailbox.hash
   end
-
+  
   def __klass__
     @klass
   end
-
+  
   def inspect
     "#<#{self.__class__}(#{@klass})>"
   end

--- a/lib/celluloid/proxy/abstract.rb
+++ b/lib/celluloid/proxy/abstract.rb
@@ -1,9 +1,7 @@
 module Celluloid::Proxy
-  CLASS_METHOD = ::Kernel.instance_method(:class)
-  
   # Looks up the actual class of instance, even if instance is a proxy.
   def self.class_of(instance)
-    CLASS_METHOD.bind(instance).call
+    (class << instance; self; end).superclass
   end
 end
 

--- a/lib/celluloid/proxy/actor.rb
+++ b/lib/celluloid/proxy/actor.rb
@@ -2,11 +2,6 @@
 class Celluloid::Proxy::Actor < Celluloid::Proxy::Abstract
   attr_reader :thread, :mailbox
 
-  # Used for reflecting on proxy objects themselves
-  def __class__
-    ::Celluloid::Proxy::Actor
-  end
-
   def initialize(mailbox, thread)
     @mailbox = mailbox
     @thread = thread

--- a/lib/celluloid/proxy/async.rb
+++ b/lib/celluloid/proxy/async.rb
@@ -1,19 +1,8 @@
 # A proxy which sends asynchronous calls to an actor
-class Celluloid::Proxy::Async < Celluloid::Proxy::Abstract
-  attr_reader :mailbox
-
+class Celluloid::Proxy::Async < Celluloid::Proxy::AbstractCall
   # Used for reflecting on proxy objects themselves
   def __class__
     ::Celluloid::Proxy::Async
-  end
-
-  def initialize(mailbox, klass)
-    @mailbox = mailbox
-    @klass = klass
-  end
-
-  def inspect
-    "#<Celluloid::Proxy::Async(#{@klass})>"
   end
 
   def method_missing(meth, *args, &block)

--- a/lib/celluloid/proxy/async.rb
+++ b/lib/celluloid/proxy/async.rb
@@ -1,10 +1,5 @@
 # A proxy which sends asynchronous calls to an actor
 class Celluloid::Proxy::Async < Celluloid::Proxy::AbstractCall
-  # Used for reflecting on proxy objects themselves
-  def __class__
-    ::Celluloid::Proxy::Async
-  end
-
   def method_missing(meth, *args, &block)
     if @mailbox == ::Thread.current[:celluloid_mailbox]
       args.unshift meth

--- a/lib/celluloid/proxy/block.rb
+++ b/lib/celluloid/proxy/block.rb
@@ -1,6 +1,7 @@
 class Celluloid::Proxy::Block
   attr_writer :execution
   attr_reader :call, :block
+  
   def initialize(mailbox, call, block)
     @mailbox = mailbox
     @call = call

--- a/lib/celluloid/proxy/cell.rb
+++ b/lib/celluloid/proxy/cell.rb
@@ -1,11 +1,6 @@
 # A proxy object returned from Celluloid::Actor.new/new_link which converts
 # the normal Ruby method protocol into an inter-actor message protocol
 class Celluloid::Proxy::Cell < Celluloid::Proxy::Sync
-  # Used for reflecting on proxy objects themselves
-  def __class__
-    ::Celluloid::Proxy::Cell
-  end
-
   def initialize(mailbox, actor_proxy, klass)
     super(mailbox, klass)
     @actor_proxy  = actor_proxy

--- a/lib/celluloid/proxy/cell.rb
+++ b/lib/celluloid/proxy/cell.rb
@@ -9,7 +9,6 @@ class Celluloid::Proxy::Cell < Celluloid::Proxy::Sync
   def initialize(mailbox, actor_proxy, klass)
     super(mailbox, klass)
     @actor_proxy  = actor_proxy
-    @sync_proxy   = ::Celluloid::Proxy::Sync.new(mailbox, klass)
     @async_proxy  = ::Celluloid::Proxy::Async.new(mailbox, klass)
     @future_proxy = ::Celluloid::Proxy::Future.new(mailbox, klass)
   end

--- a/lib/celluloid/proxy/future.rb
+++ b/lib/celluloid/proxy/future.rb
@@ -1,19 +1,8 @@
 # A proxy which creates future calls to an actor
-class Celluloid::Proxy::Future < Celluloid::Proxy::Abstract
-  attr_reader :mailbox
-
+class Celluloid::Proxy::Future < Celluloid::Proxy::AbstractCall
   # Used for reflecting on proxy objects themselves
   def __class__
     ::Celluloid::Proxy::Future
-  end
-
-  def initialize(mailbox, klass)
-    @mailbox = mailbox
-    @klass = klass
-  end
-
-  def inspect
-    "#<Celluloid::Proxy::Future(#{@klass})>"
   end
 
   def method_missing(meth, *args, &block)

--- a/lib/celluloid/proxy/future.rb
+++ b/lib/celluloid/proxy/future.rb
@@ -1,10 +1,5 @@
 # A proxy which creates future calls to an actor
 class Celluloid::Proxy::Future < Celluloid::Proxy::AbstractCall
-  # Used for reflecting on proxy objects themselves
-  def __class__
-    ::Celluloid::Proxy::Future
-  end
-
   def method_missing(meth, *args, &block)
     unless @mailbox.alive?
       fail ::Celluloid::DeadActorError, "attempted to call a dead actor: #{meth}"

--- a/lib/celluloid/proxy/sync.rb
+++ b/lib/celluloid/proxy/sync.rb
@@ -1,10 +1,5 @@
 # A proxy which sends synchronous calls to an actor
 class Celluloid::Proxy::Sync < Celluloid::Proxy::AbstractCall
-  # Used for reflecting on proxy objects themselves
-  def __class__
-    ::Celluloid::Proxy::Sync
-  end
-
   def respond_to?(meth, include_private = false)
     __class__.instance_methods.include?(meth) || method_missing(:respond_to?, meth, include_private)
   end

--- a/lib/celluloid/proxy/sync.rb
+++ b/lib/celluloid/proxy/sync.rb
@@ -1,19 +1,8 @@
 # A proxy which sends synchronous calls to an actor
-class Celluloid::Proxy::Sync < Celluloid::Proxy::Abstract
-  attr_reader :mailbox
-
+class Celluloid::Proxy::Sync < Celluloid::Proxy::AbstractCall
   # Used for reflecting on proxy objects themselves
   def __class__
     ::Celluloid::Proxy::Sync
-  end
-
-  def initialize(mailbox, klass)
-    @mailbox = mailbox
-    @klass = klass
-  end
-
-  def inspect
-    "#<Celluloid::Proxy::Sync(#{@klass})>"
   end
 
   def respond_to?(meth, include_private = false)

--- a/spec/celluloid/proxy_spec.rb
+++ b/spec/celluloid/proxy_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Celluloid::Proxy::Abstract do
+	around do |ex|
+		Celluloid.boot
+		ex.run
+		Celluloid.shutdown
+	end
+
+	let(:task_klass) { Celluloid.task_class }
+	let(:actor_class) { ExampleActorClass.create(CelluloidSpecs.included_module, task_klass) }
+	let(:actor) { actor_class.new "Troy McClure" }
+
+	let(:logger) { Specs::FakeLogger.current }
+	
+	it "should be eql? to self" do
+		expect(actor.eql? actor).to be_truthy
+	end
+	
+	it "should be eql? to self even if dead" do
+		actor.terminate
+		expect(actor.eql? actor).to be_truthy
+	end
+	
+	it "should not be eql? to other proxy objects" do
+		other_future = Celluloid::Proxy::Future.new(actor.mailbox, actor.__klass__)
+		
+		expect(actor.future.eql? other_future).to be_truthy
+	end
+end

--- a/spec/celluloid/proxy_spec.rb
+++ b/spec/celluloid/proxy_spec.rb
@@ -25,4 +25,9 @@ RSpec.describe Celluloid::Proxy::Abstract do
 		
 		expect(actor.future.eql? other_future).to be_truthy
 	end
+	
+	it "should be possible to compare with non-proxy objects" do
+		expect(actor.eql? "string").to be_falsey
+		expect("string".eql? actor).to be_falsey
+	end
 end


### PR DESCRIPTION
The shared base class additionally implements `eql?` and `hash` which look through to the target mailbox.

I believe this is a good improvement to the structure of the code. We should also check if some improvements could be made to `C::P::Block`