### PR TITLE
extending the condition event handler with the block; this solves a b…

### DIFF
--- a/lib/celluloid/system_events.rb
+++ b/lib/celluloid/system_events.rb
@@ -110,7 +110,9 @@ module Celluloid
     end
     attr_reader :task, :value
 
-    handler(&:call)
+    handler do |event|
+      event.call
+    end
 
     def call
       @task.resume(@value)


### PR DESCRIPTION
…ug introduced in jruby >9.0.0.0, which breaks with an ArgumentError exception, apparently due to the way to_proc procs are passed arguments (Fixes #694)