### PR TITLE
Set celluloid logger level to info by default unless debug is enabled…

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -463,7 +463,10 @@ end
 
 require "celluloid/exceptions"
 
-Celluloid.logger = Logger.new(STDERR)
+Celluloid.logger = Logger.new(STDERR).tap do |logger|
+  logger.level = Logger::INFO unless $CELLULOID_DEBUG
+end
+
 Celluloid.shutdown_timeout = 10
 Celluloid.log_actor_crashes = true
 


### PR DESCRIPTION
…. Fixes #667.