### PR TITLE
Conditions in loose threads loop does not take into account the diffe…

### DIFF
--- a/lib/celluloid/rspec.rb
+++ b/lib/celluloid/rspec.rb
@@ -16,7 +16,6 @@ module Specs
 
   CHECK_LOOSE_THREADS = !Nenv.ci? unless defined? CHECK_LOOSE_THREADS
   ALLOW_RETRIES = 3 unless defined? ALLOW_RETRIES
-  ALLOW_SLOW_MAILBOXES = false unless defined? ALLOW_SLOW_MAILBOXES
 
   INCLUDE_SUPPORT = [
     "env",

--- a/spec/support/configure_rspec.rb
+++ b/spec/support/configure_rspec.rb
@@ -49,7 +49,7 @@ RSpec.configure do |config|
   end
 
   config.around :each, library: :IO do |ex|
-    Celluloid.boot
+    Celluloid.init
     FileUtils.rm("/tmp/cell_sock") if File.exist?("/tmp/cell_sock")
     ex.run
     Celluloid.shutdown

--- a/spec/support/loose_threads.rb
+++ b/spec/support/loose_threads.rb
@@ -5,10 +5,6 @@ module Specs
         next unless thread
         next if thread == Thread.current
 
-        # TODO: Remove Specs::ALLOW_SLOW_MAILBOXES hax.
-        #       Allows slow shutdown of mailboxes.
-        #       Find more graceful way to do shutdown.
-
         if RUBY_PLATFORM == "java"
           # Avoid disrupting jRuby's "fiber" threads.
           name = thread.to_java.getNativeThread.get_name
@@ -36,10 +32,6 @@ module Specs
           next unless thread.backtrace.is_a?(Array)
           next if thread.backtrace.empty?
           next if thread.backtrace.first =~ /timeout\.rb/
-
-          if Specs::ALLOW_SLOW_MAILBOXES
-            next if thread.backtrace[0] =~ /sleep/ && thread.backtrace.any? { |l| l =~ /mailbox\.rb/ }
-          end
         end
 
         thread

--- a/spec/support/loose_threads.rb
+++ b/spec/support/loose_threads.rb
@@ -38,7 +38,7 @@ module Specs
           next if thread.backtrace.first =~ /timeout\.rb/
 
           if Specs::ALLOW_SLOW_MAILBOXES
-            next if thread.backtrace[0] =~ /mailbox\.rb/ && thread.backtrace[0] =~ /sleep/
+            next if thread.backtrace[0] =~ /sleep/ && thread.backtrace.any? { |l| l =~ /mailbox\.rb/ }
           end
         end
 


### PR DESCRIPTION
…rence between backtraces from ruby 2.0.0 and greater than (Fixes https://github.com/celluloid/celluloid-io/issues/165)