### PR TITLE
adding method source code path to backtrace

### DIFF
--- a/lib/celluloid/calls.rb
+++ b/lib/celluloid/calls.rb
@@ -45,10 +45,18 @@ module Celluloid
       arity = meth.arity
 
       if arity >= 0
-        fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{arity})" if @arguments.size != arity
+        if @arguments.size != arity
+          e = ArgumentError.new("wrong number of arguments (#{@arguments.size} for #{arity})")
+          e.set_backtrace(caller << "#{meth.source_location.join(':')}: in `#{meth.name}`")
+          fail e
+        end
       elsif arity < -1
         mandatory_args = -arity - 1
-        fail ArgumentError, "wrong number of arguments (#{@arguments.size} for #{mandatory_args}+)" if arguments.size < mandatory_args
+        if arguments.size < mandatory_args
+          e = ArgumentError.new("wrong number of arguments (#{@arguments.size} for #{mandatory_args}+)")
+          e.set_backtrace(caller << "#{meth.source_location.join(':')}: in `#{meth.name}`")
+          fail e
+        end
       end
     rescue => ex
       raise AbortError.new(ex)


### PR DESCRIPTION
Opening the discussion here of making celluloid backtraces more useful. 

Usually I have the problem of a method call error, because I'm passing the wrong arguments, and then I get an ugly call stack referring to celluloid internals. 

This commit solves the problem of knowing which method it was about (ArgumentError doesn't specify which method was called with wrong arguments). It doesn't solve the problem of knowing exactly where the method has been called with wrong parameters. One step at a time. 