### PR TITLE
when exit exception is not a SystemExit, then it is some other kind o…

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -169,9 +169,11 @@ module Celluloid
         if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
           # workaround for MRI bug losing exit status in at_exit block
           # http://bugs.ruby-lang.org/issues/5218
-          exit_status = $ERROR_INFO.status if $ERROR_INFO.is_a?(SystemExit)
+          # return previous status or assume something failed
+          # see https://github.com/colszowka/simplecov/issues/41
+          exit_status = ($ERROR_INFO.is_a?(SystemExit) ? $ERROR_INFO.status : 1)
           Celluloid.shutdown
-          exit exit_status if exit_status
+          exit exit_status
         else
           Celluloid.shutdown
         end


### PR DESCRIPTION
…f failure

when trying to use simplecov / single_cov with celluloid I noticed that
adding it makes other at_exit hooks no longer show an error,
which means they can no longer tell if something failed or not /
it always looks as if the exit was 0

see https://github.com/colszowka/simplecov/issues/41

makes this call failed -> also prints coverage when tests failed
https://github.com/grosser/single_cov/blob/master/lib/single_cov.rb#L67