### PR TITLE
ship less files and remove defaults

### DIFF
--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -1,11 +1,8 @@
-# -*- encoding: utf-8 -*-
-
-require File.expand_path("../culture/sync", __FILE__)
+require_relative "../culture/sync"
 
 Gem::Specification.new do |gem|
   gem.name        = "celluloid"
   gem.version     = Celluloid::VERSION
-  gem.platform    = Gem::Platform::RUBY
   gem.summary     = "Actor-based concurrent object framework for Ruby"
   gem.description = "Celluloid enables people to build concurrent programs out of concurrent objects just as easily as they build sequential programs out of sequential objects"
   gem.licenses    = ["MIT"]
@@ -15,7 +12,6 @@ Gem::Specification.new do |gem|
   gem.homepage    = "https://github.com/celluloid/celluloid"
 
   gem.required_ruby_version     = ">= 1.9.3"
-  gem.required_rubygems_version = ">= 1.3.6"
 
   gem.files        = Dir[
                       "README.md",
@@ -23,11 +19,7 @@ Gem::Specification.new do |gem|
                       "LICENSE.txt",
                       "culture/**/*",
                       "lib/**/*",
-                      "spec/**/*",
-                      "examples/*"
                     ]
-
-  gem.require_path = "lib"
 
   Celluloid::Sync::Gemspec[gem]
 end


### PR DESCRIPTION
 - makes gem lighter / faster to install and vendor/cache smaller ...
 - remove default values to make gemspec easier to read

... no idea what the culture folder is and why there is a whole other gem in there ideally don't ship that either ...

