### PR TITLE
fix $ERROR_INFO warnings

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -2,6 +2,7 @@ require "logger"
 require "thread"
 require "timeout"
 require "set"
+require "English"
 
 $CELLULOID_DEBUG = false
 $CELLULOID_MANAGED ||= false


### PR DESCRIPTION
When running with warnings enabled I get a warning about; `lib/celluloid.rb:172: warning: global variable '$ERROR_INFO' not initialized`, requiring English fixes this.
