### PR TITLE
Remove mysterious Fiber.yield

### DIFF
--- a/lib/celluloid/task/fibered.rb
+++ b/lib/celluloid/task/fibered.rb
@@ -12,8 +12,10 @@ module Celluloid
           Thread.current[:celluloid_queue] = queue
           Thread.current[:celluloid_actor_system] = actor_system
           yield
-          # TODO: Determine why infinite thread leakage happens under jRuby, if `Fiber.yield` is used:
-          Fiber.yield unless RUBY_PLATFORM == "java"
+
+          # Alleged workaround for a MRI memory leak
+          # TODO: validate/confirm this is actually necessary
+          Fiber.yield if RUBY_ENGINE == "ruby"
         end
       end
 


### PR DESCRIPTION
How did this Fiber.yield get here? What is its purpose?

I wrote Celluloid and I can't answer these questions. I don't think it belongs here. I am too lazy to sift through the commit history to find the commit that introduced it.

Per the comment also being deleted, it seems to be causing problems. I've had a few people bug me about it.

Unless there's a justification for it being here, it should be removed.