### PR TITLE
Require Ruby 2.2.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
-script: rake ci
-cache: bundler
 language: ruby
+sudo: false
+cache: bundler
+script: bundle exec rake ci
+bundler_args: --without=development
+
+branches:
+  only:
+    - master
+
 rvm:
-  - rbx-2
-  - jruby
-  - 2.2.2
-  - 2.2.0
-  - 2.1.4
-  - 2.0.0
-  - 1.9.3
-  - ruby-head
-  - jruby-head
+  - 2.2.6
+  - 2.3.3
+  - jruby-9.1.6.0
 
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: 1.9.3
-    - rvm: ruby-head
-    - rvm: jruby-head
     - env: CELLULOID_BACKPORTED=true
     - env: CELLULOID_BACKPORTED=false CELLULOID_LEAKTEST=1
     - env: CELLULOID_BACKPORTED=false CELLULOID_TASK_CLASS=Threaded
@@ -35,10 +33,3 @@ env:
 
 notifications:
   irc: "irc.freenode.org#celluloid"
-
-before_install:
-  # Only use 1 job until Travis fixes the rbx --jobs issue.
-  - if [ "$TRAVIS_RUBY_VERSION" == "rbx-2" ] ; then export BUNDLE_JOBS=1 ; else export BUNDLE_JOBS=4; fi
-
-sudo: false
-install: bundle install --without=development

--- a/README.md
+++ b/README.md
@@ -182,13 +182,27 @@ Run the following command in the directory containing `Celluloid`:
 
 ## Supported Platforms
 
-Celluloid works on Ruby 2.0+, JRuby 1.7+, and Rubinius 2.0.
+This library aims to support and is [tested against][travis] the following Ruby
+versions:
 
-JRuby or Rubinius are the preferred platforms as they support true thread-level
-parallelism when executing Ruby code, whereas MRI/YARV is constrained by a global
-interpreter lock (GIL) and can only execute one thread at a time.
+* Ruby 2.2.6+
+* Ruby 2.3.0+
+* JRuby 9.1.6.0+
 
-Celluloid requires Ruby 1.9 mode or higher on all interpreters.
+If something doesn't work on one of these versions, it's a bug.
+
+This library may inadvertently work (or seem to work) on other Ruby versions,
+however support will only be provided for the versions listed above.
+
+If you would like this library to support another Ruby version or
+implementation, you may volunteer to be a maintainer. Being a maintainer
+entails making sure all tests run and pass on that implementation. When
+something breaks on your implementation, you will be responsible for providing
+patches in a timely fashion. If critical issues for a particular implementation
+exist at the time of a major release, support for that Ruby version may be
+dropped.
+
+[travis]: http://travis-ci.org/celluloid/celluloid/
 
 ## Additional Reading
 

--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -6,26 +6,28 @@ Gem::Specification.new do |gem|
   gem.name        = "celluloid"
   gem.version     = Celluloid::VERSION
   gem.platform    = Gem::Platform::RUBY
-  gem.summary     = "Actor-based concurrent object framework for Ruby"
-  gem.description = "Celluloid enables people to build concurrent programs out of concurrent objects just as easily as they build sequential programs out of sequential objects"
   gem.licenses    = ["MIT"]
-
   gem.authors     = ["Tony Arcieri", "Donovan Keme"]
-  gem.email       = ["tony.arcieri@gmail.com", "code@extremist.digital"]
+  gem.email       = ["bascule@gmail.com", "code@extremist.digital"]
   gem.homepage    = "https://github.com/celluloid/celluloid"
+  gem.summary     = "Actor-based concurrent object framework for Ruby"
+  gem.description = <<-DESCRIPTION.strip.gsub(/\s+/, " ")
+    Celluloid enables people to build concurrent programs out of concurrent objects just as easily
+    as they build sequential programs out of sequential objects
+  DESCRIPTION
 
-  gem.required_ruby_version     = ">= 1.9.3"
-  gem.required_rubygems_version = ">= 1.3.6"
+  gem.required_ruby_version     = ">= 2.2.6"
+  gem.required_rubygems_version = ">= 2.0.0"
 
-  gem.files        = Dir[
-                      "README.md",
-                      "CHANGES.md",
-                      "LICENSE.txt",
-                      "culture/**/*",
-                      "lib/**/*",
-                      "spec/**/*",
-                      "examples/*"
-                    ]
+  gem.files = Dir[
+                    "README.md",
+                    "CHANGES.md",
+                    "LICENSE.txt",
+                    "culture/**/*",
+                    "lib/**/*",
+                    "spec/**/*",
+                    "examples/*"
+                  ]
 
   gem.require_path = "lib"
 


### PR DESCRIPTION
- Drops support for 1.9, 2.0, 2.1, JRuby 1.7, and rbx.
- Adds: 2.3, JRuby 9000

2.2.6 is the latest stable release of the 2.2 series, so require it at a minimum in the event people are unable to update to 2.3.

Dropped versions are either EOL, soon-to-be EOL, or rbx (which has been a consistent pain to support, and I don't have time to debug the problems)