### PR TITLE
Global variables: stop the bleeding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,9 +88,6 @@ Style/For:
 Style/FrozenStringLiteralComment:
   Enabled: false # TODO: enable
 
-Style/GlobalVars:
-  Enabled: false # TODO: enable
-
 Style/GuardClause:
   Enabled: false # TODO: enable
 
@@ -120,9 +117,6 @@ Style/Semicolon:
 
 Style/SingleLineBlockParams:
   Enabled: false
-
-Style/SpecialGlobalVars:
-  Enabled: false # TODO: enable
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ branches:
     - master
 
 rvm:
+  - jruby-9.1.6.0
   - 2.2.6
   - 2.3.3
-  - jruby-9.1.6.0
 
 matrix:
   fast_finish: true

--- a/examples/ring.rb
+++ b/examples/ring.rb
@@ -48,14 +48,15 @@ if $PROGRAM_NAME == __FILE__
   require "benchmark"
   SIZE  = 512
   TIMES = 10
+  ring = nil
 
   puts "*** Creating a #{SIZE} node ring..."
   puts Benchmark.measure {
-    $ring = Ring.new(SIZE)
+    ring = Ring.new(SIZE)
   }
 
   puts "*** Sending a message around #{TIMES} times"
   puts Benchmark.measure {
-    $ring.run(TIMES)
+    ring.run(TIMES)
   }
 end

--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -1,13 +1,19 @@
+# TODO: eliminate use of global variables
+require "English"
+
 require "logger"
+require "set"
 require "thread"
 require "timeout"
-require "set"
 
+# !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+# rubocop:disable Style/GlobalVars
 $CELLULOID_DEBUG = false
 $CELLULOID_MONITORING = false
 
 # TODO: gut this
 $CELLULOID_BACKPORTED = false
+# rubocop:enable Style/GlobalVars
 
 require "celluloid/version"
 
@@ -170,7 +176,7 @@ module Celluloid
       return if defined?(@shutdown_registered) && @shutdown_registered
       # Terminate all actors at exit, unless the exit is abnormal.
       at_exit do
-        Celluloid.shutdown unless $!
+        Celluloid.shutdown unless $ERROR_INFO
       end
       @shutdown_registered = true
     end
@@ -457,7 +463,10 @@ end
 require "celluloid/exceptions"
 
 Celluloid.logger = Logger.new(STDERR).tap do |logger|
+  # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+  # rubocop:disable Style/GlobalVars
   logger.level = Logger::INFO unless $CELLULOID_DEBUG
+  # rubocop:enable Style/GlobalVars
 end
 
 Celluloid.shutdown_timeout = 10

--- a/lib/celluloid/actor.rb
+++ b/lib/celluloid/actor.rb
@@ -132,7 +132,11 @@ module Celluloid
       end
 
       @proxy = Proxy::Actor.new(@mailbox, @thread)
+
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
       Celluloid::Probe.actor_created(self) if $CELLULOID_MONITORING
+      # rubocop:enable Style/GlobalVars
     end
 
     def behavior_proxy
@@ -194,7 +198,10 @@ module Celluloid
           end
 
           if message.instance_of? LinkingResponse
+            # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+            # rubocop:disable Style/GlobalVars
             Celluloid::Probe.actors_linked(self, receiver) if $CELLULOID_MONITORING
+            # rubocop:enable Style/GlobalVars
             system_events.each { |ev| @mailbox << ev }
             return
           elsif message.is_a? SystemEvent
@@ -279,11 +286,13 @@ module Celluloid
 
     # Handle standard low-priority messages
     def handle_message(message)
-      unless @handlers.handle_message(message)
-        unless @receivers.handle_message(message)
-          Internals::Logger.debug "Discarded message (unhandled): #{message}" if $CELLULOID_DEBUG
-        end
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
+      if !@handlers.handle_message(message) && !@receivers.handle_message(message) && $CELLULOID_DEBUG
+        Internals::Logger.debug "Discarded message (unhandled): #{message}"
       end
+      # rubocop:enable Style/GlobalVars
+
       message
     end
 
@@ -311,7 +320,11 @@ module Celluloid
 
     # Clean up after this actor
     def cleanup(exit_event)
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
       Celluloid::Probe.actor_died(self) if $CELLULOID_MONITORING
+      # rubocop:enable Style/GlobalVars
+
       @mailbox.shutdown
       @links.each do |actor|
         actor.mailbox << exit_event if actor.mailbox.alive?

--- a/lib/celluloid/autostart.rb
+++ b/lib/celluloid/autostart.rb
@@ -1,4 +1,7 @@
 require "celluloid"
 
+# !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+# rubocop:disable Style/GlobalVars
+
 Celluloid.boot
 Celluloid.register_shutdown unless defined?($CELLULOID_TEST) && $CELLULOID_TEST

--- a/lib/celluloid/debug.rb
+++ b/lib/celluloid/debug.rb
@@ -1,1 +1,3 @@
+# !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+# rubocop:disable Style/GlobalVars
 $CELLULOID_DEBUG = true

--- a/lib/celluloid/group.rb
+++ b/lib/celluloid/group.rb
@@ -3,7 +3,7 @@ module Celluloid
     attr_accessor :group
 
     def initialize
-      @pid = $$
+      @pid = $PROCESS_ID
       @mutex = Mutex.new
       @group = []
       @running = true
@@ -27,7 +27,7 @@ module Celluloid
     end
 
     def forked?
-      @pid != $$
+      @pid != $PROCESS_ID
     end
 
     def to_a

--- a/lib/celluloid/internals/cpu_counter.rb
+++ b/lib/celluloid/internals/cpu_counter.rb
@@ -6,8 +6,6 @@ module Celluloid
           @cores ||= count_cores
         end
 
-        private unless $CELLULOID_TEST
-
         def count_cores
           from_result(from_env || from_sysdev || from_java || from_proc || from_win32ole || from_sysctl) || 1
         end

--- a/lib/celluloid/internals/logger.rb
+++ b/lib/celluloid/internals/logger.rb
@@ -7,7 +7,10 @@ module Celluloid
         end
 
         def debug(string)
+          # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+          # rubocop:disable Style/GlobalVars
           Celluloid.logger.debug(decorate(string)) if $CELLULOID_DEBUG
+          # rubocop:enable Style/GlobalVars
         end
 
         def info(string)
@@ -37,7 +40,10 @@ module Celluloid
 
       # Send a debug message
       def debug(string)
+        # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+        # rubocop:disable Style/GlobalVars
         Celluloid.logger.debug(string) if Celluloid.logger && $CELLULOID_DEBUG
+        # rubocop:enable Style/GlobalVars
       end
 
       # Send a info message

--- a/lib/celluloid/logger.rb
+++ b/lib/celluloid/logger.rb
@@ -1,2 +1,0 @@
-# DEPRECATE
-require "celluloid/internals/logger"

--- a/lib/celluloid/mailbox.rb
+++ b/lib/celluloid/mailbox.rb
@@ -159,7 +159,10 @@ module Celluloid
     end
 
     def dead_letter(message)
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
       Internals::Logger.debug "Discarded message (mailbox is dead): #{message}" if $CELLULOID_DEBUG
+      # rubocop:enable Style/GlobalVars
     end
 
     def mailbox_full

--- a/lib/celluloid/probe.rb
+++ b/lib/celluloid/probe.rb
@@ -1,6 +1,9 @@
 require "celluloid"
 
+# !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+# rubocop:disable Style/GlobalVars
 $CELLULOID_MONITORING = true
+# rubocop:enable Style/GlobalVars
 
 module Celluloid
   class Probe
@@ -41,7 +44,10 @@ module Celluloid
       private
 
       def trigger_event(name, *args)
+        # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+        # rubocop:disable Style/GlobalVars
         return unless $CELLULOID_MONITORING
+        # rubocop:enable Style/GlobalVars
 
         EVENTS_BUFFER << [name, args]
         probe_actor = Actor[:probe_actor]

--- a/lib/celluloid/rspec.rb
+++ b/lib/celluloid/rspec.rb
@@ -37,11 +37,14 @@ module Specs
   ].freeze
 end
 
+# !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+# rubocop:disable Style/GlobalVars
 $CELLULOID_DEBUG = true
 
 # Require but disable, so it has to be explicitly enabled in tests
 require "celluloid/probe"
 $CELLULOID_MONITORING = false
+# rubocop:enable Style/GlobalVars
 
 Celluloid.shutdown_timeout = 1
 

--- a/lib/celluloid/system_events.rb
+++ b/lib/celluloid/system_events.rb
@@ -5,7 +5,10 @@ module Celluloid
       if handler = SystemEvent.handle(event.class)
         send(handler, event)
       else
+        # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+        # rubocop:disable Style/GlobalVars
         Internals::Logger.debug "Discarded message (unhandled): #{message}" if $CELLULOID_DEBUG
+        # rubocop:enable Style/GlobalVars
       end
     end
   end
@@ -87,7 +90,11 @@ module Celluloid
 
     handler do |event|
       @name = event.name
+
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
       Celluloid::Probe.actor_named(self) if $CELLULOID_MONITORING
+      # rubocop:enable Style/GlobalVars
     end
 
     def initialize(name)

--- a/lib/celluloid/task.rb
+++ b/lib/celluloid/task.rb
@@ -63,11 +63,14 @@ module Celluloid
 
       @status = status
 
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
       if $CELLULOID_DEBUG && @dangerous_suspend
         Internals::Logger.with_backtrace(caller[2...8]) do |logger|
           logger.warn "Dangerously suspending task: type=#{@type.inspect}, meta=#{@meta.inspect}, status=#{@status.inspect}"
         end
       end
+      # rubocop:enable Style/GlobalVars
 
       value = signal
 
@@ -106,12 +109,16 @@ module Celluloid
       raise "Cannot terminate an exclusive task" if exclusive?
 
       if running?
+        # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+        # rubocop:disable Style/GlobalVars
         if $CELLULOID_DEBUG
           Internals::Logger.with_backtrace(backtrace) do |logger|
             type = @dangerous_suspend ? :warn : :debug
             logger.send(type, "Terminating task: type=#{@type.inspect}, meta=#{@meta.inspect}, status=#{@status.inspect}")
           end
         end
+        # rubocop:enable Style/GlobalVars
+
         exception = TaskTerminated.new("task was terminated")
         exception.set_backtrace(caller)
         resume exception
@@ -139,11 +146,14 @@ module Celluloid
     end
 
     def guard(message)
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
       if @guard_warnings
         Internals::Logger.warn message if $CELLULOID_DEBUG
       else
         raise message if $CELLULOID_DEBUG
       end
+      # rubocop:enable Style/GlobalVars
     end
 
     private

--- a/lib/celluloid/test.rb
+++ b/lib/celluloid/test.rb
@@ -1,3 +1,5 @@
+# !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+# rubocop:disable Style/GlobalVars
 $CELLULOID_TEST = true
 
 require "celluloid/autostart"

--- a/spec/celluloid/block_spec.rb
+++ b/spec/celluloid/block_spec.rb
@@ -1,3 +1,7 @@
+# !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+# TODO: remove use of global variables
+# rubocop:disable Style/GlobalVars
+
 RSpec.describe "Blocks", actor_system: :global do
   class MyBlockActor
     include Celluloid

--- a/spec/support/reset_class_variables.rb
+++ b/spec/support/reset_class_variables.rb
@@ -11,7 +11,11 @@ module Specs
     end
 
     def reset_probe(value)
+      # !!! DO NOT INTRODUCE ADDITIONAL GLOBAL VARIABLES !!!
+      # rubocop:disable Style/GlobalVars
       $CELLULOID_MONITORING = !value.nil?
+      # rubocop:enable Style/GlobalVars
+
       replace_const(Celluloid::Probe, :EVENTS_BUFFER, value)
     end
 


### PR DESCRIPTION
There's excessive use of global variables throughout the codebase, sometimes coupled together across gems, which makes things difficult to debug or change.

Global variables are an antipattern and shouldn't be used.

This enables RuboCop's lints for global variables and marks all current usages of globals with scare comments.

In a future pass these globals should be replaced with e.g. static methods.