### PR TITLE
Return false from Celluloid.running? if Celluloid.boot hasn't been called

### DIFF
--- a/lib/celluloid.rb
+++ b/lib/celluloid.rb
@@ -169,6 +169,8 @@ module Celluloid
 
     def running?
       actor_system && actor_system.running?
+    rescue Error
+      false
     end
 
     # de TODO Anticipate outside process finalizer that would by-pass this.


### PR DESCRIPTION
Closes #748 