### PR TITLE
Travis: Use JRuby 9.1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.1.6.0
+  - jruby-9.1.7.0
   - 2.2.6
   - 2.3.3
 


### PR DESCRIPTION
This updates the test matrix to latest release of JRuby.