### PR TITLE
Misspellings

### DIFF
--- a/lib/celluloid/exceptions.rb
+++ b/lib/celluloid/exceptions.rb
@@ -9,7 +9,7 @@ module Celluloid
   class NotTaskError < Celluloid::Error; end # Asked to do task-related things outside a task
   class DeadTaskError < Celluloid::Error; end # Trying to resume a dead task
   class TaskTerminated < Celluloid::Interruption; end # Kill a running task after terminate
-  class TaskTimeout < Celluloid::TimedOut; end # A timeout occured before the given request could complete
+  class TaskTimeout < Celluloid::TimedOut; end # A timeout occurred before the given request could complete
   class ConditionError < Celluloid::Error; end
   class AbortError < Celluloid::Error # The sender made an error, not the current actor
     attr_reader :cause

--- a/spec/celluloid/calls_spec.rb
+++ b/spec/celluloid/calls_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Celluloid::Call::Sync, actor_system: :global do
       allow(logger).to receive(:crash).with("Actor crashed!", NoMethodError)
 
       expect do
-        actor.the_method_that_wasnt_there
+        actor.the_method_that_was_not_there
       end.to raise_exception(NoMethodError)
     end
 

--- a/spec/shared/actor_examples.rb
+++ b/spec/shared/actor_examples.rb
@@ -947,7 +947,7 @@ RSpec.shared_examples "a Celluloid Actor" do
       expect(actor).to be_sleeping
 
       future.value
-      # I got 0.558 (in a slighly busy MRI) which is outside 0.05 of 0.5, so let's use (0.05 * 2)
+      # I got 0.558 (in a slightly busy MRI) which is outside 0.05 of 0.5, so let's use (0.05 * 2)
       expect(Time.now - started_at).to be_within(Specs::TIMER_QUANTUM * 2).of interval
     end
 

--- a/spec/support/configure_rspec.rb
+++ b/spec/support/configure_rspec.rb
@@ -41,7 +41,7 @@ RSpec.configure do |config|
         "\n** Crash: #{msg.inspect}(#{ex.inspect})\n  Backtrace:\n    (crash) #{call_stack * "\n    (crash) "}"\
           "\n  Exception Backtrace (#{ex.inspect}):\n    (ex) #{ex.backtrace * "\n    (ex) "}"
       end.join("\n")
-      raise "Actor crashes occured (please stub/mock if these are expected): #{crashes}"
+      raise "Actor crashes occurred (please stub/mock if these are expected): #{crashes}"
     end
     @fake_logger = nil
     Specs.assert_no_loose_threads!("after example: #{ex.description}") if Specs::CHECK_LOOSE_THREADS


### PR DESCRIPTION
This trivial PR edits code comments so that the whole project passes a run of the misspellings tool.

([I happened to use Celluloid as an example](http://ollehost.dk/blog/2017/02/25/automate-finding-misspellings-in-source-code/) of where there were a few commonly found misspellings. In order to make things clearer for the reader, and not just be a spelling stickler, I created this PR.)

- In the interest of having 0 misspellings results, I walked over a reference joke to The Man Who Wasn't There in a spec. Perhaps now that the reference joke is destroyed, I should pick a clearer method name ('non_existent_method' for instance)
- All edits affect `git blame` output, of course
