### PR TITLE
Travis: jruby-9.1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.1.9.0
+  - jruby-9.1.10.0
   - 2.2.7
   - 2.3.4
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby. (each_with_index had an issue.)