### PR TITLE
Bring back fix for #696 from #612, in new ::Group::* convention.

### DIFF
--- a/lib/celluloid/group.rb
+++ b/lib/celluloid/group.rb
@@ -3,6 +3,7 @@ module Celluloid
     attr_accessor :group
 
     def initialize
+      @pid = $$
       @mutex = Mutex.new
       @group = []
       @running = true
@@ -25,7 +26,12 @@ module Celluloid
       to_a.each { |thread| yield thread }
     end
 
+    def forked?
+      @pid != $$
+    end
+
     def to_a
+      return [] if forked?
       res = nil
       @mutex.synchronize { res = @group.dup }
       res

--- a/lib/celluloid/version.rb
+++ b/lib/celluloid/version.rb
@@ -1,3 +1,3 @@
 module Celluloid
-  VERSION = "0.17.3"
+  VERSION = "0.17.4"
 end


### PR DESCRIPTION
So this is a patch to make the fix from #696 and apply it to the 0-17-stable branch so a 0.17.4 release can be made.  

This fix has been in the 0.18pre branch for a while.  This would be easier than trying to resolve all the open issue in 0.18 branch.