### PR TITLE
Travis: use latest JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - 2.2.7
   - 2.3.4
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/11/08/jruby-9-1-14-0.html