### PR TITLE
Bring back fix for #696 from #612, in new ::Group::* convention. (take 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 script: rake ci
 language: ruby
 rvm:
-  - rbx-2
   - jruby
   - 2.2.2
   - 2.2.0

--- a/lib/celluloid/group.rb
+++ b/lib/celluloid/group.rb
@@ -3,6 +3,7 @@ module Celluloid
     attr_accessor :group
 
     def initialize
+      @pid = $$
       @mutex = Mutex.new
       @group = []
       @running = true
@@ -25,7 +26,12 @@ module Celluloid
       to_a.each { |thread| yield thread }
     end
 
+    def forked?
+      @pid != $$
+    end
+
     def to_a
+      return [] if forked?
       res = nil
       @mutex.synchronize { res = @group.dup }
       res

--- a/lib/celluloid/version.rb
+++ b/lib/celluloid/version.rb
@@ -1,3 +1,3 @@
 module Celluloid
-  VERSION = "0.17.3"
+  VERSION = "0.17.4"
 end


### PR DESCRIPTION
This was proposed in PR #763, but we are stuck with rbx-2 not being installable via rvm in travis.

I'm attempting to use the prebuilt binaries that travis says they have here:

http://rubies.travis-ci.org/

