### PR TITLE
gemspec: Metadata with supported links

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,11 @@ Lint/UselessAssignment:
 Metrics/AbcSize:
   Enabled: false # TODO: enable
 
+Metrics/BlockLength:
+  Exclude:
+    - "celluloid.gemspec"
+    - "spec/**/*"
+
 Metrics/BlockNesting:
   Enabled: false # TODO: enable
 

--- a/celluloid.gemspec
+++ b/celluloid.gemspec
@@ -18,6 +18,15 @@ Gem::Specification.new do |spec|
     Celluloid enables people to build concurrent programs out of concurrent objects just as easily
     as they build sequential programs out of sequential objects
   DESCRIPTION
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/celluloid/celluloid/issues",
+    "changelog_uri" => "https://github.com/celluloid/celluloid/blob/master/CHANGES.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/celluloid",
+    "homepage_uri" => "https://celluloid.io/",
+    "mailing_list_uri" => "http://groups.google.com/group/celluloid-ruby",
+    "source_code_uri" => "https://github.com/celluloid/celluloid",
+    "wiki_uri" => "https://github.com/celluloid/celluloid/wiki"
+  }
 
   spec.require_path = "lib"
   spec.files        = Dir["*.md", "*.txt", "lib/**/*", "spec/**/*", "examples/*"]


### PR DESCRIPTION
This PR adds gemspec metadata for all supported link types.

(It also makes room in the linting rules for this long metadata section.)
