### PR TITLE
Travis: use jruby-9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - master
 
 rvm:
-  - jruby-9.2.0.0
+  - jruby-9.2.5.0
   - 2.2.7
   - 2.3.4
 


### PR DESCRIPTION
This PR is about using latest generally available JRuby.