### PR TITLE
Travis config: drop old configuration sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 script: bundle exec rake ci
 bundler_args: --without=development


### PR DESCRIPTION
This PR drops an unused Travis configuration line.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration