### PR TITLE
Travis: Include Ruby 2.5, 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ branches:
 
 rvm:
   - jruby-9.2.5.0
-  - 2.2.7
-  - 2.3.4
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This PR updates the matrix using info from https://github.com/rvm/rvm/blob/master/config/known.