### PR TITLE
CI: Use 2.6.1, jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ branches:
     - master
 
 rvm:
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
   - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6.0
+  - 2.6.1
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)

And MRI 2.6.1.