### PR TITLE
Update Ruby versions in CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ branches:
 
 rvm:
   - jruby-9.2.6.0
+  - jruby-9.2.11.1
   - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.5
   - 2.6.2
+  - 2.7.1
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
New Ruby versions have many good features. However, I think they don't have any features that would be worth updating to. It wouldn't make the code a lot shorter or more easily understood. 

Updating the version would mean that potential users won't be able to upgrade to the new Celluloid version, and that would be bad. In version 2.6 and 2.7, there are a lot of new interesting features that would be fun to experiment with, but it would lock pretty much everyone out.

I collected the features in [a file](https://github.com/emesepadanyi/fictional-telegram/blob/master/notes_on_rubyversions.md) for up to v2.6. 

Even though I don't think we should update to a new version, it is a good idea to include the new versions for JRuby and Ruby in Travis.